### PR TITLE
Bounty change unlock period in block height is set to 7-days.

### DIFF
--- a/contracts/gateway/GatewayBase.sol
+++ b/contracts/gateway/GatewayBase.sol
@@ -75,8 +75,11 @@ contract GatewayBase is Organized {
     uint8 constant REVOCATION_PENALTY = 150;
 
     //todo identify how to get block time for both chains
-    /** Unlock period for change bounty in block height. */
-    uint256 private constant BOUNTY_CHANGE_UNLOCK_PERIOD = 100;
+    /**
+     * Unlock period of 7-days for change bounty in block height.
+     * Considering aux block generation time per block is 3-secs.
+     */
+    uint256 public constant BOUNTY_CHANGE_UNLOCK_PERIOD = 201600;
 
 
     /* Public Variables */
@@ -295,16 +298,7 @@ contract GatewayBase is Organized {
         onlyOrganization
         returns(uint256)
     {
-        proposedBounty = _proposedBounty;
-        proposedBountyUnlockHeight = block.number.add(BOUNTY_CHANGE_UNLOCK_PERIOD);
-
-        emit BountyChangeInitiated(
-                bounty,
-                _proposedBounty,
-                proposedBountyUnlockHeight
-        );
-
-        return _proposedBounty;
+        return initiateBountyAmountChangeInternal(_proposedBounty, BOUNTY_CHANGE_UNLOCK_PERIOD);
     }
 
     /**
@@ -666,6 +660,35 @@ contract GatewayBase is Organized {
         returns(uint256 penalty_)
     {
         penalty_ = _bounty.mul(REVOCATION_PENALTY).div(100);
+    }
+
+    /**
+     * Internal method to propose new bounty. This is added for large block
+     * heights value for unlocking bounty change.
+     *
+     * @param _proposedBounty proposed bounty amount.
+     * @param _bountyChangePeriod  Unlock period for change bounty in
+     *                             block height.
+     *
+     * @return uint256 proposed bounty amount.
+     */
+    function initiateBountyAmountChangeInternal(
+        uint256 _proposedBounty,
+        uint256 _bountyChangePeriod
+    )
+        internal
+        returns(uint256)
+    {
+        proposedBounty = _proposedBounty;
+        proposedBountyUnlockHeight = block.number.add(_bountyChangePeriod);
+
+        emit BountyChangeInitiated(
+            bounty,
+            _proposedBounty,
+            proposedBountyUnlockHeight
+        );
+
+        return _proposedBounty;
     }
 
     /* Private Functions */

--- a/contracts/test/gateway/TestGatewayBase.sol
+++ b/contracts/test/gateway/TestGatewayBase.sol
@@ -31,6 +31,12 @@ import "../../lib/StateRootInterface.sol";
  */
 contract TestGatewayBase is GatewayBase {
 
+    /* Constants */
+
+    /** Unlock period for change bounty in block height. */
+    uint256 public constant BOUNTY_CHANGE_UNLOCK_PERIOD = 100;
+
+
     /* Constructor */
 
     /**
@@ -171,5 +177,24 @@ contract TestGatewayBase is GatewayBase {
         external
     {
         super.registerOutboxProcess(_account, 1, _messageHash);
+    }
+
+    /**
+     * @notice Method allows organization to propose new bounty amount.
+     *
+     * @dev This is used for testing purpose.
+     *
+     * @param _proposedBounty proposed bounty amount.
+     *
+     * @return uint256 proposed bounty amount.
+     */
+    function initiateBountyAmountChange(uint256 _proposedBounty)
+        external
+        onlyOrganization
+        returns(uint256)
+    {
+
+        return initiateBountyAmountChangeInternal(_proposedBounty, BOUNTY_CHANGE_UNLOCK_PERIOD);
+
     }
 }

--- a/contracts/test/gateway/TestGatewayBase.sol
+++ b/contracts/test/gateway/TestGatewayBase.sol
@@ -34,7 +34,7 @@ contract TestGatewayBase is GatewayBase {
     /* Constants */
 
     /** Unlock period for change bounty in block height. */
-    uint256 public constant BOUNTY_CHANGE_UNLOCK_PERIOD = 100;
+    uint256 public constant BOUNTY_CHANGE_UNLOCK_PERIOD = 2;
 
 
     /* Constructor */

--- a/test/gateway/gateway_base/bounty_change.js
+++ b/test/gateway/gateway_base/bounty_change.js
@@ -26,7 +26,7 @@ const BN = require('bn.js');
 const MockOrganization = artifacts.require('MockOrganization.sol');
 const Utils = require('../../../test/test_lib/utils');
 
-const unlockTimeInBlocks = 100;
+const unlockTimeInBlocks = 2;
 
 async function proposeBountyChange(
   gatewayBaseInstance,
@@ -211,10 +211,6 @@ contract('GatewayBase.sol', (accounts) => {
     let gatewayBaseInstance;
     const owner = accounts[2];
     const worker = accounts[3];
-    let unlockHeight;
-    let currentBlock;
-    const proposedBounty = new BN(50);
-    const currentBounty = new BN(100);
 
     beforeEach(async () => {
       const dummyStateRootProviderAddress = accounts[0];

--- a/test/gateway/gateway_base/bounty_change.js
+++ b/test/gateway/gateway_base/bounty_change.js
@@ -18,6 +18,7 @@
 //
 // ----------------------------------------------------------------------------
 
+const TestGatewayBase = artifacts.require('./TestGatewayBase.sol');
 const GatewayBase = artifacts.require('./GatewayBase.sol');
 
 const BN = require('bn.js');
@@ -75,7 +76,7 @@ contract('GatewayBase.sol', (accounts) => {
 
       const organization = await MockOrganization.new(owner, worker);
 
-      gatewayBaseInstance = await GatewayBase.new(
+      gatewayBaseInstance = await TestGatewayBase.new(
         dummyStateRootProviderAddress,
         bounty,
         organization.address,
@@ -142,7 +143,7 @@ contract('GatewayBase.sol', (accounts) => {
 
       const organization = await MockOrganization.new(owner, worker);
 
-      gatewayBaseInstance = await GatewayBase.new(
+      gatewayBaseInstance = await TestGatewayBase.new(
         dummyStateRootProviderAddress,
         bounty,
         organization.address,
@@ -204,5 +205,46 @@ contract('GatewayBase.sol', (accounts) => {
         gatewayBaseInstance.confirmBountyAmountChange({ from: accounts[5] }),
       );
     });
+  });
+
+  describe('Confirm unlock period', async () => {
+    let gatewayBaseInstance;
+    const owner = accounts[2];
+    const worker = accounts[3];
+    let unlockHeight;
+    let currentBlock;
+    const proposedBounty = new BN(50);
+    const currentBounty = new BN(100);
+
+    beforeEach(async () => {
+      const dummyStateRootProviderAddress = accounts[0];
+
+      const bounty = new BN(100);
+
+      const organization = await MockOrganization.new(owner, worker);
+
+      gatewayBaseInstance = await GatewayBase.new(
+        dummyStateRootProviderAddress,
+        bounty,
+        organization.address,
+      );
+    });
+
+    it('should verify the bounty change unlock period value is equal to 7 days', async () => {
+
+      // Considering block generation time is 3-sec per block.
+
+      const expectedBountyChangeUnlockPeriod = new BN(201600);
+      const bountyChangeUnlockPeriod = await gatewayBaseInstance.BOUNTY_CHANGE_UNLOCK_PERIOD.call();
+
+      assert.strictEqual(
+        expectedBountyChangeUnlockPeriod.eq(bountyChangeUnlockPeriod),
+        true,
+        `Unlock period for bounty in block height is not equal to 7-days. Expected value is ` +
+        `${expectedBountyChangeUnlockPeriod} but got ${bountyChangeUnlockPeriod} from contract`
+      );
+
+    });
+
   });
 });


### PR DESCRIPTION
PR contains following :-
1. `BOUNTY_CHANGE_UNLOCK_PERIOD` constant is set to value which will enable to unlock bounty change period to 7-days.
2. Updated test-cases.
3. Added test-case to verify the unlock period in contract is set to the expected value.

Partially fixes :- #662 