### PR TITLE
Removed stake and redeem terminology from the gateway base

### DIFF
--- a/contracts/gateway/GatewayBase.sol
+++ b/contracts/gateway/GatewayBase.sol
@@ -70,7 +70,7 @@ contract GatewayBase is Organized {
     uint8 constant MESSAGE_BOX_OFFSET = 7;
 
     /**
-     * Penalty in bounty amount percentage charged to staker on revert stake.
+     * Penalty in bounty amount percentage charged to message sender on revert message.
      */
     uint8 constant REVOCATION_PENALTY = 150;
 


### PR DESCRIPTION
Fixes #689 

Gateway base should be more general, it should talk about messages, not of the specific type of messages like stake or redeem. 