### PR TITLE
Contracts: type token as address in UtilityToken

### DIFF
--- a/contracts/gateway/OSTPrime.sol
+++ b/contracts/gateway/OSTPrime.sol
@@ -95,7 +95,7 @@ contract OSTPrime is UtilityToken, OSTPrimeConfig, Mutex {
      * @param _organization Address of a contract that manages organization.
      */
     constructor(
-        EIP20Interface _valueToken,
+        address _valueToken,
         OrganizationInterface _organization
     )
         public

--- a/contracts/gateway/UtilityToken.sol
+++ b/contracts/gateway/UtilityToken.sol
@@ -44,7 +44,7 @@ contract UtilityToken is EIP20Token, Organized, UtilityTokenInterface {
     /* Storage */
 
     /** Address of the EIP20 token (branded token) in origin chain. */
-    EIP20Interface public token;
+    address public token;
 
     /** Address of CoGateway contract. */
     address public coGateway;
@@ -76,7 +76,7 @@ contract UtilityToken is EIP20Token, Organized, UtilityTokenInterface {
      * @param _organization Address of a contract that manages organization.
      */
     constructor(
-        EIP20Interface _token,
+        address _token,
         string memory _symbol,
         string memory _name,
         uint8 _decimals,
@@ -87,7 +87,7 @@ contract UtilityToken is EIP20Token, Organized, UtilityTokenInterface {
         EIP20Token(_symbol, _name, _decimals)
     {
         require(
-            address(_token) != address(0),
+            _token != address(0),
             "Token address should not be zero."
         );
 

--- a/contracts/test/gateway/MockUtilityToken.sol
+++ b/contracts/test/gateway/MockUtilityToken.sol
@@ -50,7 +50,7 @@ contract MockUtilityToken is UtilityToken {
      * @param _organization Address of a contract that manages organization.
      */
     constructor(
-        EIP20Interface _token,
+        address _token,
         string memory _symbol,
         string memory _name,
         uint8 _decimals,

--- a/contracts/test/gateway/TestOSTPrime.sol
+++ b/contracts/test/gateway/TestOSTPrime.sol
@@ -38,7 +38,7 @@ contract TestOSTPrime is OSTPrime {
      * @param _organization Address of a contract that manages organization.
      */
     constructor(
-        EIP20Interface _valueToken,
+        address _valueToken,
         OrganizationInterface _organization
     )
         public

--- a/contracts/test/gateway/TestUtilityToken.sol
+++ b/contracts/test/gateway/TestUtilityToken.sol
@@ -42,7 +42,7 @@ contract TestUtilityToken is UtilityToken {
      * @param _organization Address of an organization contract.
      */
     constructor(
-        EIP20Interface _token,
+        address _token,
         string memory _symbol,
         string memory _name,
         uint8 _decimals,


### PR DESCRIPTION
Cast `token`/`_token` as `address` instead of `EIP20Interface` in `UtilityToken` and related contracts.

✏️N.B.: There will be conflicts with #710.

Resolves #702.