### PR TITLE
Gateways should store roots in ring buffer

### DIFF
--- a/contracts/gateway/GatewayBase.sol
+++ b/contracts/gateway/GatewayBase.sol
@@ -68,15 +68,15 @@ contract GatewayBase is Organized {
     /* Constants */
 
     /** Position of message bus in the storage. */
-    uint8 constant MESSAGE_BOX_OFFSET = 7;
+    uint8 public constant MESSAGE_BOX_OFFSET = 7;
 
     /** The max number of storage roots to store. */
-    uint256 private constant MAX_STORAGE_ROOTS = 256;
+    uint256 public constant MAX_STORAGE_ROOTS = 256;
 
     /**
      * Penalty in bounty amount percentage charged to message sender on revert message.
      */
-    uint8 constant REVOCATION_PENALTY = 150;
+    uint8 public constant REVOCATION_PENALTY = 150;
 
     //todo identify how to get block time for both chains
     /**
@@ -151,7 +151,6 @@ contract GatewayBase is Organized {
      * nonce of the particular address. Refer getNonce for the details.
      */
     mapping(address => bytes32) private outboxActiveProcess;
-
 
     CircularBufferUintLib.BufferUint storageRootBuffer;
 

--- a/contracts/lib/CircularBufferUintLib.sol
+++ b/contracts/lib/CircularBufferUintLib.sol
@@ -23,7 +23,7 @@ pragma solidity ^0.5.0;
 /**
  * @title Circular buffer for `uint`s.
  *
- * @notice This contract represents a circular buffer that stores `uint`s. When
+ * @notice This library represents a circular buffer that stores `uint`s. When
  *         a set number of `uint`s have been stored, the storage starts
  *         overwriting older entries. It overwrites always the oldest entry in
  *         the buffer.
@@ -46,12 +46,14 @@ library CircularBufferUintLib {
         uint256 index;
     }
 
+
+    /* Internal functions */
+
     /**
-     * @notice Set buffer max item limit
+     * @notice Set buffer max item limit/
      *
-     * @param _item The item to store in the circular buffer.
+     * @param _maxItems The item to store in the circular buffer.
      * @param _buffer Uint buffer.
-     *
      */
     function setMaxItemLimit(
         uint256 _maxItems,
@@ -72,6 +74,17 @@ library CircularBufferUintLib {
         _buffer.items.length = _maxItems;
     }
 
+    /**
+     * @notice Store a new item in the circular buffer.
+     *
+     * @param _item The item to store in the circular buffer.
+     * @param _buffer The circular buffer.
+     *
+     * @return overwrittenItem_ The item that was in the circular buffer's
+     *                          position where the new item is now stored. The
+     *                          overwritten item is no longer available in the
+     *                          circular buffer.
+     */
     function store(
         uint256 _item,
         BufferUint storage _buffer
@@ -81,12 +94,25 @@ library CircularBufferUintLib {
             uint256 overwrittenItem_
         )
     {
+        require(
+            _buffer.items.length > 0,
+            "Buffer max item limit is not set."
+        );
+
         nextIndex(_buffer);
 
         overwrittenItem_ = _buffer.items[_buffer.index];
         _buffer.items[_buffer.index] = _item;
+
     }
 
+    /**
+     * @notice Get the most recent item that was stored in the circular buffer.
+     *
+     * @param _buffer The circular buffer.
+     *
+     * @return head_ The most recently stored item.
+     */
     function head(
         BufferUint storage _buffer
     )
@@ -94,9 +120,23 @@ library CircularBufferUintLib {
         view
         returns(uint256 head_)
     {
+        require(
+            _buffer.items.length > 0,
+            "Buffer max item limit is not set."
+        );
         head_ = _buffer.items[_buffer.index];
     }
 
+
+    /* Private functions */
+
+    /**
+     * @notice Updates the index of the circular buffer to point to the next
+     *         slot of where to store an item. Resets to zero if it gets to the
+     *         end of the array that represents the circular.
+     *
+     * @param _buffer The circular buffer.
+     */
     function nextIndex(
         BufferUint storage _buffer
     )

--- a/contracts/lib/CircularBufferUintLib.sol
+++ b/contracts/lib/CircularBufferUintLib.sol
@@ -1,0 +1,110 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+/**
+ * @title Circular buffer for `uint`s.
+ *
+ * @notice This contract represents a circular buffer that stores `uint`s. When
+ *         a set number of `uint`s have been stored, the storage starts
+ *         overwriting older entries. It overwrites always the oldest entry in
+ *         the buffer.
+ */
+library CircularBufferUintLib {
+
+    struct BufferUint {
+        /**
+         * The circular buffer that stores the latest `items.length` items. Once
+         * `items.length` items were stored, items will be overwritten starting at
+         * zero.
+         */
+        uint256[] items;
+
+        /**
+         * The current index in the items array. The index increases up to
+         * `items.length - 1` and then resets to zero in an endless loop. This
+         * means that a new item will always overwrite the oldest item.
+         */
+        uint256 index;
+    }
+
+    /**
+     * @notice Set buffer max item limit
+     *
+     * @param _item The item to store in the circular buffer.
+     * @param _buffer Uint buffer.
+     *
+     */
+    function setMaxItemLimit(
+        uint256 _maxItems,
+        BufferUint storage _buffer
+    )
+        internal
+    {
+        require(
+            _buffer.items.length == 0,
+            "Buffer max item limit is already set."
+        );
+
+        require(
+            _maxItems > 0,
+            "The max number of items to store in a circular buffer must be greater than 0."
+        );
+
+        _buffer.items.length = _maxItems;
+    }
+
+    function store(
+        uint256 _item,
+        BufferUint storage _buffer
+    )
+        internal
+        returns(
+            uint256 overwrittenItem_
+        )
+    {
+        nextIndex(_buffer);
+
+        overwrittenItem_ = _buffer.items[_buffer.index];
+        _buffer.items[_buffer.index] = _item;
+    }
+
+    function head(
+        BufferUint storage _buffer
+    )
+        internal
+        view
+        returns(uint256 head_)
+    {
+        head_ = _buffer.items[_buffer.index];
+    }
+
+    function nextIndex(
+        BufferUint storage _buffer
+    )
+        private
+    {
+        _buffer.index++;
+        if (_buffer.index == _buffer.items.length) {
+            _buffer.index = 0;
+        }
+    }
+}

--- a/contracts/test/gateway/MockGatewayBase.sol
+++ b/contracts/test/gateway/MockGatewayBase.sol
@@ -102,9 +102,9 @@ contract MockGatewayBase is GatewayBase {
             // return true
             return true;
         }
-        
+
         // On successful proof verification storage root is returned other wise
-        // transaction is reverted. 
+        // transaction is reverted.
         bytes32 storageRoot = MockGatewayLib.proveAccount(
             _rlpAccount,
             _rlpParentNodes,

--- a/contracts/test/lib/TestCircularBufferUintLib.sol
+++ b/contracts/test/lib/TestCircularBufferUintLib.sol
@@ -1,0 +1,82 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+import "../../lib/CircularBufferUintLib.sol";
+
+/**
+ * @title Test contract for the circular buffer for `uint`s.
+ *
+ * @notice The methods on the circular buffer are internal and therefore not
+ *         testable from the JS layer. This proxy contract wraps the original
+ *         implementation and exposes external methods which proxy the internal
+ *         methods of the circular buffer under test.
+ */
+contract TestCircularBufferUintLib {
+
+    CircularBufferUintLib.BufferUint public storageBuffer;
+
+    /**
+     * @notice Set the max item size for storage buffer.
+     *
+     * @param _maxItems Defines how many items this test buffer stores before
+     *                  overwriting older items.
+     */
+    function setMaxItemLimit(uint256 _maxItems) external {
+        CircularBufferUintLib.setMaxItemLimit(
+            _maxItems,
+            storageBuffer
+        );
+    }
+
+    /**
+     * @notice Store a new item in the circular test buffer.
+     *
+     * @param _item The item to store in the circular test buffer.
+     *
+     * @return overwrittenItem_ The item that was in the circular test buffer's
+     *                          position where the new item is now stored. The
+     *                          overwritten item is no longer available in the
+     *                          circular test buffer.
+     */
+    function store(uint256 _item) external returns(uint256 overwrittenItem_) {
+        overwrittenItem_ = CircularBufferUintLib.store(_item, storageBuffer);
+    }
+
+    /**
+     * @notice Get the most recent item that was stored in the circular test
+     *         buffer.
+     *
+     * @return head_ The most recently stored item.
+     */
+    function head() external view returns(uint256 head_) {
+        head_ = CircularBufferUintLib.head(storageBuffer);
+    }
+
+    /**
+     * @notice Get the max item size of the circular test buffer.
+     *
+     * @return maxItems_ The max item size of circular test buffer.
+     */
+    function getMaxItemLimit() external view returns (uint256 maxItems_) {
+        maxItems_ = storageBuffer.items.length;
+    }
+}

--- a/test/lib/circular_buffer_uint_lib/head.js
+++ b/test/lib/circular_buffer_uint_lib/head.js
@@ -1,0 +1,69 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const BN = require('bn.js');
+const Utils = require('../../test_lib/utils.js');
+
+const CircularBufferUint = artifacts.require('TestCircularBufferUintLib');
+
+contract('CircularBufferUintLib.head()', async (accounts) => {
+
+  var circularBufferUint;
+  beforeEach(async () => {
+    circularBufferUint = await CircularBufferUint.new();
+  });
+
+  it('should fail when buffer max limit is not set', async () => {
+    await Utils.expectRevert(
+      circularBufferUint.head.call(),
+      'Buffer max item limit is not set.'
+    );
+  });
+
+  it('should return zero when the buffer is empty', async () => {
+    await circularBufferUint.setMaxItemLimit(100);
+
+    let head = await circularBufferUint.head.call();
+    assert.strictEqual(
+      head.eqn(0),
+      true,
+      'Head must be at zero.',
+    );
+  });
+
+  it('should return correct head', async () => {
+    const bufferLength = 10;
+    await circularBufferUint.setMaxItemLimit(bufferLength);
+
+    let expectedHead = new BN(0);
+    for (let i = 0; i <= 25; i++) {
+      let head = await circularBufferUint.head.call();
+      assert.strictEqual(
+        head.eq(expectedHead),
+        true,
+        `Head must be ${expectedHead.toString(10)}.`,
+      );
+      expectedHead = new BN(i);
+      await circularBufferUint.store(new BN(i));
+    }
+
+  });
+
+});

--- a/test/lib/circular_buffer_uint_lib/set_max_item_limit.js
+++ b/test/lib/circular_buffer_uint_lib/set_max_item_limit.js
@@ -1,0 +1,59 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const Utils = require('../../test_lib/utils.js');
+
+const CircularBufferUint = artifacts.require('TestCircularBufferUintLib');
+
+contract('CircularBufferUintLib.setMaxItemLimit()', async (accounts) => {
+
+  var circularBufferUint;
+  beforeEach(async () => {
+    circularBufferUint = await CircularBufferUint.new();
+  });
+
+  it('should fail when max limit is zero', async () => {
+    await Utils.expectRevert(
+      circularBufferUint.setMaxItemLimit(0),
+      'The max number of items to store in a circular buffer must be greater than 0.'
+    );
+  });
+
+  it('should set max item limit', async () => {
+    await circularBufferUint.setMaxItemLimit(100);
+
+    let maxLimit = await circularBufferUint.getMaxItemLimit.call();
+    assert.strictEqual(
+      maxLimit.eqn(100),
+      true,
+      'Buffer max limit should be 100.',
+    );
+
+  });
+
+  it('should fail when max limit is already set once', async () => {
+    await circularBufferUint.setMaxItemLimit(100);
+    await Utils.expectRevert(
+      circularBufferUint.setMaxItemLimit(200),
+      'Buffer max item limit is already set.'
+    );
+  });
+
+});

--- a/test/lib/circular_buffer_uint_lib/store.js
+++ b/test/lib/circular_buffer_uint_lib/store.js
@@ -1,0 +1,105 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const BN = require('bn.js');
+const Utils = require('../../test_lib/utils.js');
+
+const CircularBufferUint = artifacts.require('TestCircularBufferUintLib');
+
+contract('CircularBufferUintLib.store()', async (accounts) => {
+
+  var circularBufferUint;
+  beforeEach(async () => {
+    circularBufferUint = await CircularBufferUint.new();
+  });
+
+  it('should fail when buffer max limit is not set', async () => {
+    await Utils.expectRevert(
+      circularBufferUint.store(new BN(1)),
+      'Buffer max item limit is not set.'
+    );
+  });
+
+  it('stores the given number of max items', async () => {
+    /*
+     * The first ten items are `0`, because that is the buffer length and
+     * in the loop it will check for data at a lower index than was written.
+     */
+    const data = [
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(0),
+      new BN(1),
+      new BN(2),
+      new BN(3),
+      new BN(4),
+      new BN(5),
+      new BN(6),
+      new BN(7),
+      new BN(8),
+      new BN(9),
+      new BN(10),
+      new BN(11),
+      new BN(12),
+      new BN(13),
+      new BN(14),
+      new BN(15),
+      new BN(16),
+      new BN(17),
+      new BN(18),
+      new BN(19),
+      new BN(20),
+    ];
+
+    /*
+     * Buffer length is less than the length of the array of test data. This
+     * means, that by iterating over all test data, the buffer will start
+     * overwriting old values. In the loop, it checks that the buffer
+     * returns the correct overwritten value.
+     */
+    const bufferLength = 10;
+    await circularBufferUint.setMaxItemLimit(bufferLength);
+
+    /*
+     *  Start at `i = bufferLength` to be able to query for test data at a
+     * lower index.
+     */
+    const count = data.length;
+    for (let i = bufferLength; i < count; i++) {
+      const previousItem = await circularBufferUint.store.call(data[i]);
+      const expectedPreviousItem = data[i - bufferLength];
+      assert(
+        previousItem.eq(expectedPreviousItem),
+        'The contract did not return the expected item that should '
+        + 'have been overwritten.',
+      );
+
+      await circularBufferUint.store(data[i]);
+    }
+  });
+
+});


### PR DESCRIPTION
Fixes: #698
Was potentially done in #669, but this required interface change and the variable index of message box would change.

This PR implements the logic without the interface change. This includes the library.
We can evaluate on which logic should be adapted.

This PR includes the code change, unit tests for the library.

- With Library approach, there is no interface change. No efforts for backward compatibility.
- With the contract approach, the interface will change and the JS layer needs additional effort to provide backward compatibility.

If this approach is acceptable by all then I will add a few more test cases.