### PR TITLE
Staker proxy

### DIFF
--- a/contracts/gateway/ComposerInterface.sol
+++ b/contracts/gateway/ComposerInterface.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+
+interface ComposerInterface {
+    function removeStakerProxy(address _owner) external returns(bool);
+}

--- a/contracts/gateway/EIP20Gateway.sol
+++ b/contracts/gateway/EIP20Gateway.sol
@@ -55,6 +55,7 @@ pragma solidity ^0.5.0;
 
 import "./SimpleStake.sol";
 import "./GatewayBase.sol";
+import "./EIP20GatewayInterface.sol";
 import "../utilitytoken/contracts/organization/contracts/OrganizationInterface.sol";
 
 /**
@@ -63,7 +64,7 @@ import "../utilitytoken/contracts/organization/contracts/OrganizationInterface.s
  * @notice EIP20Gateway act as medium to send messages from origin chain to
  *         auxiliary chain. Currently gateway supports stake and revert stake message.
  */
-contract EIP20Gateway is GatewayBase {
+contract EIP20Gateway is EIP20GatewayInterface, GatewayBase {
 
     /* Events */
 

--- a/contracts/gateway/EIP20GatewayInterface.sol
+++ b/contracts/gateway/EIP20GatewayInterface.sol
@@ -57,7 +57,7 @@ interface EIP20GatewayInterface {
     /**
      * @notice Get the nonce for the given account address.
      *
-     * @param _account Account address for which the nonce is to fetched.
+     * @param _account Account address for which the nonce is to be fetched.
      *
      * @return The nonce.
      */

--- a/contracts/gateway/EIP20GatewayInterface.sol
+++ b/contracts/gateway/EIP20GatewayInterface.sol
@@ -1,0 +1,89 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+import "../lib/EIP20Interface.sol";
+
+
+interface EIP20GatewayInterface {
+
+    /**
+     * @notice Initiates the stake process. In order to stake the staker
+     *         needs to approve Gateway contract for stake amount.
+     *         Staked amount is transferred from staker address to
+     *         Gateway contract. Bounty amount is also transferred from staker.
+     *
+     * @param _amount Stake amount that will be transferred from the staker
+     *                account.
+     * @param _beneficiary The address in the auxiliary chain where the utility
+     *                     tokens will be minted.
+     * @param _gasPrice Gas price that staker is ready to pay to get the stake
+     *                  and mint process done.
+     * @param _gasLimit Gas limit that staker is ready to pay.
+     * @param _nonce Nonce of the staker address.
+     * @param _hashLock Hash Lock provided by the facilitator.
+     *
+     * @return messageHash_ Message hash is unique for each request.
+     */
+    function stake(
+        uint256 _amount,
+        address _beneficiary,
+        uint256 _gasPrice,
+        uint256 _gasLimit,
+        uint256 _nonce,
+        bytes32 _hashLock
+    )
+        external
+        returns (bytes32 messageHash_);
+
+    /**
+     * @notice Get the nonce for the given account address.
+     *
+     * @param _account Account address for which the nonce is to fetched.
+     *
+     * @return The nonce.
+     */
+    function getNonce(address _account)
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @notice Amount of EIP20 which is staked by facilitator.
+     *
+     * @return The amount.
+     */
+    function bounty() external view returns (uint256);
+
+    /**
+     * @notice Get the value token of this gateway.
+     *
+     * @return The address of the value token.
+     */
+    function valueToken() external view returns (EIP20Interface);
+
+    /**
+     * @notice Get the base token of this gateway.
+     *
+     * @return The address of the base token.
+     */
+    function baseToken() external view returns (EIP20Interface);
+}

--- a/contracts/gateway/GatewayBase.sol
+++ b/contracts/gateway/GatewayBase.sol
@@ -278,11 +278,11 @@ contract GatewayBase is Organized, CircularBufferUint {
     }
 
     /**
-     * @notice Get the nonce for the given account address
+     * @notice Get the nonce for the given account address.
      *
-     * @param _account Account address for which the nonce is to fetched
+     * @param _account Account address for which the nonce is to be fetched.
      *
-     * @return nonce
+     * @return nonce.
      */
     function getNonce(address _account)
         external

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -1,0 +1,200 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+import "./ComposerInterface.sol";
+import "./EIP20Gateway.sol";
+import "../lib/EIP20Interface.sol";
+
+
+/**
+ * @title StakerProxy is a contract that is deployed by the composer to allow
+ *        staking of multiple users from within the same composer contract.
+ * @notice The composer contract will deploy StakerProxy contracts on behalf of
+ *         the owner. Only the owner can self-destruct the StakerProxy and
+ *         receive all stored value.
+ */
+contract StakerProxy {
+
+    /* Storage */
+
+    /** The composer that deployed this contract. */
+    ComposerInterface public composer;
+
+    /** The composer deployed the StakerProxy on behalf of the owner. */
+    address payable public owner;
+
+    /** A mutex to prevent reentrancy from a malicious gateway. */
+    bool stakeMutex;
+
+
+    /* Modifiers */
+
+    /** Requires that msg.sender is the composer */
+    modifier onlyComposer() {
+        require(
+            msg.sender == address(composer),
+            "This function can only be called by the composer."
+        );
+
+        _;
+    }
+
+    /** Requires that msg.sender is the owner. */
+    modifier onlyOwner() {
+        require(
+            msg.sender == owner,
+            "This function can only be called by the owner."
+        );
+
+        _;
+    }
+
+    /** Mutex to prevent reentrancy attack. */
+    modifier mutexed() {
+        assert(!stakeMutex);
+        stakeMutex = true;
+
+        _;
+
+        stakeMutex = false;
+    }
+
+
+    /* Special Functions */
+
+    /**
+     * @notice Must be constructed by a contract that implements the
+     *         `ComposerInterface`.
+     *
+     * @param _owner The owner that this proxy is deployed for.
+     */
+    constructor(address payable _owner) public {
+        composer = ComposerInterface(msg.sender);
+        owner = _owner;
+    }
+
+
+    /* External Functions */
+
+    /**
+     * @notice Initiates the stake process. In order to stake, the stake and
+     *         bounty amounts must first be transferred to the StakerProxy.
+     *         Staked amount is then transferred to the Gateway contract.
+     *         Bounty amount is also transferred to the Gateway contract.
+     *
+     * @param _amount Stake amount that will be transferred.
+     * @param _beneficiary The address in the auxiliary chain where the utility
+     *                     tokens will be minted.
+     * @param _gasPrice Gas price that staker is ready to pay to get the stake
+     *                  and mint process done.
+     * @param _gasLimit Gas limit that staker is ready to pay.
+     * @param _nonce The nonce to verify it is as expected.
+     * @param _hashLock Hash lock provided by the facilitator.
+     * @param _gateway On which gateway to stake.
+     *
+     * @return messageHash_ Message hash is unique for each request.
+     */
+    function stake(
+        uint256 _amount,
+        address _beneficiary,
+        uint256 _gasPrice,
+        uint256 _gasLimit,
+        uint256 _nonce,
+        bytes32 _hashLock,
+        EIP20Gateway _gateway
+    )
+        external
+        onlyComposer
+        mutexed
+        returns (bytes32 messageHash_)
+    {
+        approveTransfers(_gateway, _amount);
+        uint256 nonce = _gateway.getNonce(address(this));
+        require(
+            nonce == _nonce,
+            "Nonce must match nonce expected by gateway."
+        );
+
+        messageHash_ = _gateway.stake(
+            _amount,
+            _beneficiary,
+            _gasPrice,
+            _gasLimit,
+            nonce,
+            _hashLock
+        );
+    }
+
+    /**
+     * @notice Transfers EIP20 token to destination address.
+     *
+     * @param _token EIP20 token address.
+     * @param _to Address to which tokens are transferred.
+     * @param _value Amount of tokens to be transferred.
+     */
+    function transferToken(
+        EIP20Interface _token,
+        address _to,
+        uint256 _value
+    )
+        external
+        onlyOwner
+    {
+        require(
+            address(_token) != address(0),
+            "EIP20 token address is zero."
+        );
+        require(
+            _token.transfer(_to, _value),
+            "EIP20Token transfer returned false."
+        );
+    }
+
+    /**
+     * @notice Destroys this contract. Make sure that you use `transferToken`
+     *         to transfer all remaining token balance of this contract.
+     */
+    function selfDestruct() external onlyOwner {
+        composer.removeStakerProxy(owner);
+
+        selfdestruct(owner);
+    }
+
+
+    /* Private Functions */
+
+    /**
+     * @notice Approves the transfer of the amount and bounty from this
+     *         contract to the gateway.
+     *
+     * @param _gateway The gateway to approve the transfer for.
+     * @param _amount The amount to stake.
+     */
+    function approveTransfers(EIP20Gateway _gateway, uint256 _amount) private {
+        EIP20Interface valueToken = _gateway.valueToken();
+        valueToken.approve(address(_gateway), _amount);
+
+        uint256 bounty = _gateway.bounty();
+        EIP20Interface baseToken = _gateway.baseToken();
+        baseToken.approve(address(_gateway), bounty);
+    }
+}

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -148,6 +148,8 @@ contract StakerProxy {
     /**
      * @notice Transfers EIP20 token to destination address.
      *
+     * @dev It is ok to to be able to transfer to the zero address.
+     *
      * @param _token EIP20 token address.
      * @param _to Address to which tokens are transferred.
      * @param _value Amount of tokens to be transferred.
@@ -162,8 +164,8 @@ contract StakerProxy {
         onlyOwner
     {
         require(
-            _to != address(0),
-            "Recipient may not be address zero."
+            address(_token) != address(0),
+            "The token address may not be address zero."
         );
         require(
             _token.transfer(_to, _value),

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -127,12 +127,13 @@ contract StakerProxy {
         mutexed
         returns (bytes32 messageHash_)
     {
-        approveTransfers(_gateway, _amount);
         uint256 nonce = _gateway.getNonce(address(this));
         require(
             nonce == _nonce,
             "Nonce must match nonce expected by gateway."
         );
+
+        approveTransfers(_gateway, _amount);
 
         messageHash_ = _gateway.stake(
             _amount,

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -192,7 +192,12 @@ contract StakerProxy {
      * @param _gateway The gateway to approve the transfer for.
      * @param _amount The amount to stake.
      */
-    function approveTransfers(EIP20GatewayInterface _gateway, uint256 _amount) private {
+    function approveTransfers(
+        EIP20GatewayInterface _gateway,
+        uint256 _amount
+    )
+        private
+    {
         EIP20Interface valueToken = _gateway.valueToken();
         valueToken.approve(address(_gateway), _amount);
 

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.5.0;
 // ----------------------------------------------------------------------------
 
 import "./ComposerInterface.sol";
-import "./EIP20Gateway.sol";
+import "./EIP20GatewayInterface.sol";
 import "../lib/EIP20Interface.sol";
 
 
@@ -120,7 +120,7 @@ contract StakerProxy {
         uint256 _gasLimit,
         uint256 _nonce,
         bytes32 _hashLock,
-        EIP20Gateway _gateway
+        EIP20GatewayInterface _gateway
     )
         external
         onlyComposer
@@ -189,7 +189,7 @@ contract StakerProxy {
      * @param _gateway The gateway to approve the transfer for.
      * @param _amount The amount to stake.
      */
-    function approveTransfers(EIP20Gateway _gateway, uint256 _amount) private {
+    function approveTransfers(EIP20GatewayInterface _gateway, uint256 _amount) private {
         EIP20Interface valueToken = _gateway.valueToken();
         valueToken.approve(address(_gateway), _amount);
 

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -173,7 +173,8 @@ contract StakerProxy {
 
     /**
      * @notice Destroys this contract. Make sure that you use `transferToken`
-     *         to transfer all remaining token balance of this contract.
+     *         to transfer all remaining token balance of this contract before
+     *         calling this method.
      */
     function selfDestruct() external onlyOwner {
         composer.removeStakerProxy(owner);

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -158,11 +158,12 @@ contract StakerProxy {
         uint256 _value
     )
         external
+        mutexed
         onlyOwner
     {
         require(
-            address(_token) != address(0),
-            "EIP20 token address is zero."
+            _to != address(0),
+            "Recipient may not be address zero."
         );
         require(
             _token.transfer(_to, _value),

--- a/contracts/test/gateway/SpyEIP20Gateway.sol
+++ b/contracts/test/gateway/SpyEIP20Gateway.sol
@@ -1,0 +1,76 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+import "./SpyToken.sol";
+
+
+/**
+ * @title A test double gateway where you can check sent values.
+ *
+ * @notice Use this spy if you need to investigate which values were sent to
+ *         the gateway.
+ */
+contract SpyEIP20Gateway {
+    uint256 public bounty = 1337;
+    uint256 public expectedNonce = 42;
+    bytes32 public messageHash = "b";
+
+    SpyToken public valueToken;
+    SpyToken public baseToken;
+
+    uint256 public amount;
+    address public beneficiary;
+    uint256 public gasPrice;
+    uint256 public gasLimit;
+    uint256 public nonce;
+    bytes32 public hashLock;
+
+    constructor() public {
+        valueToken = new SpyToken();
+        baseToken = new SpyToken();
+    }
+
+    function stake(
+        uint256 _amount,
+        address _beneficiary,
+        uint256 _gasPrice,
+        uint256 _gasLimit,
+        uint256 _nonce,
+        bytes32 _hashLock
+    )
+        external
+        returns (bytes32 messageHash_)
+    {
+        amount = _amount;
+        beneficiary = _beneficiary;
+        gasPrice = _gasPrice;
+        gasLimit = _gasLimit;
+        nonce = _nonce;
+        hashLock = _hashLock;
+
+        messageHash_ = messageHash;
+    }
+
+    function getNonce(address) external view returns(uint256) {
+        return expectedNonce;
+    }
+}

--- a/contracts/test/gateway/SpyToken.sol
+++ b/contracts/test/gateway/SpyToken.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+
+/**
+ * @title A test double taken where you can check sent values.
+ *
+ * @notice Use this spy if you need to investigate which values were sent to
+ *         the token.
+ */
+contract SpyToken {
+    address public approveFrom;
+    address public approveTo;
+    uint256 public approveAmount;
+
+    function approve(address _to, uint256 _amount) external returns (bool success_) {
+        approveFrom = msg.sender;
+        approveTo = _to;
+        approveAmount = _amount;
+
+        success_ = true;
+    }
+}

--- a/test/gateway/staker_proxy/constructor.js
+++ b/test/gateway/staker_proxy/constructor.js
@@ -1,0 +1,54 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+'use strict';
+
+const StakerProxy = artifacts.require('./StakerProxy.sol');
+const web3 = require('../../../test/test_lib/web3.js');
+
+contract('StakerProxy.constructor()', (accounts) => {
+  it('should pass with correct parameters', async () => {
+    const [deployer, owner] = accounts;
+    const stakerProxy = await StakerProxy.new(
+      owner,
+      { from: deployer },
+    );
+
+    assert.strictEqual(
+      web3.utils.isAddress(stakerProxy.address),
+      true,
+      'Deployed staker proxy contract does not have a valid contract address.',
+    );
+
+    const composer = await stakerProxy.composer.call();
+    const ownerFromContract = await stakerProxy.owner.call();
+
+    assert.strictEqual(
+      composer,
+      deployer,
+      'Expected token address is different from actual address.',
+    );
+    assert.strictEqual(
+      ownerFromContract,
+      owner,
+      'Expected token address is different from actual address.',
+    );
+  });
+});

--- a/test/gateway/staker_proxy/constructor.js
+++ b/test/gateway/staker_proxy/constructor.js
@@ -43,12 +43,12 @@ contract('StakerProxy.constructor()', (accounts) => {
     assert.strictEqual(
       composer,
       deployer,
-      'Expected token address is different from actual address.',
+      'Expected composer address is different from the actual address.',
     );
     assert.strictEqual(
       ownerFromContract,
       owner,
-      'Expected token address is different from actual address.',
+      'Expected owner address is different from the actual address.',
     );
   });
 });

--- a/test/gateway/staker_proxy/stake.js
+++ b/test/gateway/staker_proxy/stake.js
@@ -77,63 +77,63 @@ contract('StakerProxy.stake()', (accounts) => {
     assert.strictEqual(
       (await spyGateway.gasPrice.call()).toString(10),
       gasPrice,
-      'The spy did not record the correct gas price staked',
+      'The spy did not record the correct gas price staked.',
     );
 
     assert.strictEqual(
       (await spyGateway.gasLimit.call()).toString(10),
       gasLimit,
-      'The spy did not record the correct gas limit staked',
+      'The spy did not record the correct gas limit staked.',
     );
 
     assert.strictEqual(
       (await spyGateway.nonce.call()).toString(10),
       nonce,
-      'The spy did not record the correct nonce staked',
+      'The spy did not record the correct nonce staked.',
     );
 
     assert.strictEqual(
       (await spyGateway.hashLock.call()),
       hashLock,
-      'The spy did not record the correct hash lock staked',
+      'The spy did not record the correct hash lock staked.',
     );
 
 
     assert.strictEqual(
       (await spyValueToken.approveFrom.call()),
       stakerProxy.address,
-      'The spy did not record the correct approval from',
+      'The spy did not record the correct approval from.',
     );
 
     assert.strictEqual(
       (await spyValueToken.approveTo.call()),
       spyGateway.address,
-      'The spy did not record the correct approval to',
+      'The spy did not record the correct approval to.',
     );
 
     assert.strictEqual(
       (await spyValueToken.approveAmount.call()).toString(10),
       amount,
-      'The spy did not record the correct approval amount',
+      'The spy did not record the correct approval amount.',
     );
 
-
+    // Below assertions concern the tokens:
     assert.strictEqual(
       (await spyBaseToken.approveFrom.call()),
       stakerProxy.address,
-      'The spy did not record the correct approval from',
+      'The spy did not record the correct approval from.',
     );
 
     assert.strictEqual(
       (await spyBaseToken.approveTo.call()),
       spyGateway.address,
-      'The spy did not record the correct approval to',
+      'The spy did not record the correct approval to.',
     );
 
     assert.strictEqual(
       (await spyBaseToken.approveAmount.call()).toString(10),
       (await spyGateway.bounty.call()).toString(10),
-      'The spy did not record the correct approval amount',
+      'The spy did not record the correct approval amount.',
     );
   });
 
@@ -152,7 +152,7 @@ contract('StakerProxy.stake()', (accounts) => {
     assert.strictEqual(
       messageHash,
       (await spyGateway.messageHash.call()),
-      'The spy did not record the correct amount staked.',
+      'The spy did not record the correct message hash.',
     );
   });
 

--- a/test/gateway/staker_proxy/stake.js
+++ b/test/gateway/staker_proxy/stake.js
@@ -1,0 +1,191 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+'use strict';
+
+const SpyGateway = artifacts.require('./SpyEIP20Gateway.sol');
+const SpyToken = artifacts.require('./SpyToken.sol');
+const StakerProxy = artifacts.require('./StakerProxy.sol');
+const Utils = require('../../test_lib/utils');
+
+contract('StakerProxy.stake()', (accounts) => {
+  const [composer, owner, beneficiary, someoneElse] = accounts;
+
+  const amount = '10001';
+  const gasPrice = '400';
+  const gasLimit = '10000000';
+  const nonce = '42';
+  const hashLock = '0x6666666666666666666666666666666666666666666666666666666666666666';
+
+  let stakerProxy;
+  let spyGateway;
+
+  beforeEach(async () => {
+    // Deploying from a simple account, as proxy won't call on it in this test.
+    stakerProxy = await StakerProxy.new(
+      owner,
+      { from: composer },
+    );
+
+    spyGateway = await SpyGateway.new();
+  });
+
+  it('should approve and stake on the gateway', async () => {
+    const spyValueToken = await SpyToken.at(await spyGateway.valueToken.call());
+    const spyBaseToken = await SpyToken.at(await spyGateway.baseToken.call());
+
+    await stakerProxy.stake(
+      amount,
+      beneficiary,
+      gasPrice,
+      gasLimit,
+      nonce,
+      hashLock,
+      spyGateway.address,
+      { from: composer },
+    );
+
+    assert.strictEqual(
+      (await spyGateway.amount.call()).toString(10),
+      amount,
+      'The spy did not record the correct amount staked.',
+    );
+
+    assert.strictEqual(
+      (await spyGateway.beneficiary.call()),
+      beneficiary,
+      'The spy did not record the correct beneficiary.',
+    );
+
+    assert.strictEqual(
+      (await spyGateway.gasPrice.call()).toString(10),
+      gasPrice,
+      'The spy did not record the correct gas price staked',
+    );
+
+    assert.strictEqual(
+      (await spyGateway.gasLimit.call()).toString(10),
+      gasLimit,
+      'The spy did not record the correct gas limit staked',
+    );
+
+    assert.strictEqual(
+      (await spyGateway.nonce.call()).toString(10),
+      nonce,
+      'The spy did not record the correct nonce staked',
+    );
+
+    assert.strictEqual(
+      (await spyGateway.hashLock.call()),
+      hashLock,
+      'The spy did not record the correct hash lock staked',
+    );
+
+
+    assert.strictEqual(
+      (await spyValueToken.approveFrom.call()),
+      stakerProxy.address,
+      'The spy did not record the correct approval from',
+    );
+
+    assert.strictEqual(
+      (await spyValueToken.approveTo.call()),
+      spyGateway.address,
+      'The spy did not record the correct approval to',
+    );
+
+    assert.strictEqual(
+      (await spyValueToken.approveAmount.call()).toString(10),
+      amount,
+      'The spy did not record the correct approval amount',
+    );
+
+
+    assert.strictEqual(
+      (await spyBaseToken.approveFrom.call()),
+      stakerProxy.address,
+      'The spy did not record the correct approval from',
+    );
+
+    assert.strictEqual(
+      (await spyBaseToken.approveTo.call()),
+      spyGateway.address,
+      'The spy did not record the correct approval to',
+    );
+
+    assert.strictEqual(
+      (await spyBaseToken.approveAmount.call()).toString(10),
+      (await spyGateway.bounty.call()).toString(10),
+      'The spy did not record the correct approval amount',
+    );
+  });
+
+  it('should return the message hash from the gateway', async () => {
+    const messageHash = await stakerProxy.stake.call(
+      amount,
+      beneficiary,
+      gasPrice,
+      gasLimit,
+      nonce,
+      hashLock,
+      spyGateway.address,
+      { from: composer },
+    );
+
+    assert.strictEqual(
+      messageHash,
+      (await spyGateway.messageHash.call()),
+      'The spy did not record the correct amount staked.',
+    );
+  });
+
+  it('should fail if not called by the composer', async () => {
+    await Utils.expectRevert(
+      stakerProxy.stake.call(
+        amount,
+        beneficiary,
+        gasPrice,
+        gasLimit,
+        nonce,
+        hashLock,
+        spyGateway.address,
+        { from: someoneElse },
+      ),
+      'This function can only be called by the composer.',
+    );
+  });
+
+  it('should fail if nonces do not match', async () => {
+    const wrongNonce = nonce - 5;
+    await Utils.expectRevert(
+      stakerProxy.stake.call(
+        amount,
+        beneficiary,
+        gasPrice,
+        gasLimit,
+        wrongNonce,
+        hashLock,
+        spyGateway.address,
+        { from: composer },
+      ),
+      'Nonce must match nonce expected by gateway.',
+    );
+  });
+});

--- a/test/gateway/staker_proxy/transfer_token.js
+++ b/test/gateway/staker_proxy/transfer_token.js
@@ -1,0 +1,90 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+'use strict';
+
+const MockToken = artifacts.require('./MockToken.sol');
+const StakerProxy = artifacts.require('./StakerProxy.sol');
+const Utils = require('../../test_lib/utils');
+
+contract('StakerProxy.transferToken()', (accounts) => {
+  const [deployer, owner, someoneElse] = accounts;
+  const transferValue = '1000';
+
+  let stakerProxy;
+
+  beforeEach(async () => {
+    // Account deployer works, as no composer is queried for `transferToken`.
+    stakerProxy = await StakerProxy.new(
+      owner,
+      { from: deployer },
+    );
+  });
+
+  it('should send the tokens to the desired recipient', async () => {
+    const mockToken = await MockToken.new({ from: deployer });
+    await mockToken.transfer(
+      stakerProxy.address,
+      transferValue,
+      { from: deployer },
+    );
+
+    await stakerProxy.transferToken(
+      mockToken.address,
+      someoneElse,
+      transferValue,
+      { from: owner },
+    );
+
+    const balance = await mockToken.balanceOf.call(someoneElse);
+
+    assert.strictEqual(
+      balance.toString(10),
+      transferValue,
+      'The balance of `someoneElse` should equal the transfer value after the transfer.',
+    );
+  });
+
+  it('should fail if not called by the owner', async () => {
+    // Other function arguments are only placeholders as the call will fail on the modifier.
+    await Utils.expectRevert(
+      stakerProxy.transferToken(
+        someoneElse,
+        someoneElse,
+        transferValue,
+        { from: someoneElse },
+      ),
+      'This function can only be called by the owner.',
+    );
+  });
+
+  it('should fail if attempting transfer to zero address', async () => {
+    // Other function arguments are only placeholders as the call will fail on first require.
+    await Utils.expectRevert(
+      stakerProxy.transferToken(
+        someoneElse,
+        Utils.NULL_ADDRESS,
+        transferValue,
+        { from: owner },
+      ),
+      'Recipient may not be address zero.',
+    );
+  });
+});

--- a/test/gateway/staker_proxy/transfer_token.js
+++ b/test/gateway/staker_proxy/transfer_token.js
@@ -75,16 +75,16 @@ contract('StakerProxy.transferToken()', (accounts) => {
     );
   });
 
-  it('should fail if attempting transfer to zero address', async () => {
+  it('should fail if attempting to transfer at token address zero.', async () => {
     // Other function arguments are only placeholders as the call will fail on first require.
     await Utils.expectRevert(
       stakerProxy.transferToken(
-        someoneElse,
         Utils.NULL_ADDRESS,
+        someoneElse,
         transferValue,
         { from: owner },
       ),
-      'Recipient may not be address zero.',
+      'The token address may not be address zero.',
     );
   });
 });


### PR DESCRIPTION
A new staker proxy contract to stake on the gateway.

Temporarily added a composer interface to be able to call `removeStakerProxy`.
See also comment on https://github.com/OpenST/mosaic-contracts/issues/742.

Added unit tests for the proxy's methods.
Added new test doubles to ease writing of unit tests.

Fixes #741 