### PR TITLE
Remove redundant commands from travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,8 @@ notifications:
     on_failure: always
 node_js:
   - "8"
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install nodejs
-  - sudo apt-get install npm
-install:
-  - npm ci
 before_script:
   - ./tools/runGanacheCli.sh </dev/null 1>/dev/null 2>&1 &
-  - npm run compile
   - npm run compile:ts
 script:
   - npm run ${TEST_SUITE}


### PR DESCRIPTION
In an effort to speed up the travis ci build:

* installation of node/npm is done based on `node_js`
* `npm ci` is the default npm installation command
* truffle compilation is done automatically