### PR TITLE
Update unit test to handle arbitrary token decimals

### DIFF
--- a/contracts/test/gateway/MockToken.sol
+++ b/contracts/test/gateway/MockToken.sol
@@ -38,16 +38,19 @@ contract MockToken is EIP20Interface, MockTokenConfig {
     mapping(address => uint256) balances;
     mapping(address => mapping (address => uint256)) allowed;
 
-    constructor() public {
+    constructor(uint8 _decimals) public {
+        uint256 decimalsFactor = 10**uint256(_decimals);
+        uint256 tokensMax = 800000000 * decimalsFactor;
+
         tokenSymbol = TOKEN_SYMBOL;
         tokenName = TOKEN_NAME;
-        tokenDecimals = TOKEN_DECIMALS;
-        tokenTotalSupply = TOKENS_MAX;
-        balances[msg.sender] = TOKENS_MAX;
+        tokenDecimals = _decimals;
+        tokenTotalSupply = tokensMax;
+        balances[msg.sender] = tokensMax;
 
         // According to the ERC20 standard, a token contract which creates new tokens should trigger
         // a Transfer event and transfers of 0 values must also fire the event.
-        emit Transfer(address(0), msg.sender, TOKENS_MAX);
+        emit Transfer(address(0), msg.sender, tokensMax);
     }
 
     function name() public view returns (string memory) {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "test:integration": "cd test_integration && ./main.sh",
     "test:tools": "npm run test:deployment_tool && npm run test:generate_proof && npm run test:fuzzy_proof_generator",
     "test:deployment_tool": "mocha tools/deployment_tool/test",
-    "test:generate_proof": "cd proof_generation && ./main.sh",
+    "test:generate_proof": "./proof_generation/main.sh",
     "test:fuzzy_proof_generator": "./tools/fuzzy_proof_generator_tool/test/run.sh",
     "ganache": "sh tools/runGanacheCli.sh",
     "build-package": "node tools/build_package.js",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "compile-all": "truffle compile --all",
     "compile:ts": "tsc --target es5",
     "test": "truffle test",
+    "test:range": "./tools/test_range.sh",
     "test:integration": "cd test_integration && ./main.sh",
     "test:tools": "npm run test:deployment_tool && npm run test:generate_proof && npm run test:fuzzy_proof_generator",
     "test:deployment_tool": "mocha tools/deployment_tool/test",

--- a/proof_generation/deployer.js
+++ b/proof_generation/deployer.js
@@ -49,6 +49,7 @@ async function deployer(web3Provider, accounts) {
   const organization = await MockOrganization.new(owner, worker);
   const burner = Utils.NULL_ADDRESS;
   const maxStorageRootItems = new BN(50);
+  const tokenDecimals = 18;
 
   const anchor = await Anchor.new(
     remoteChainId,
@@ -57,14 +58,14 @@ async function deployer(web3Provider, accounts) {
     maxNumberOfStateRoots,
     organization.address,
   );
-  const mockToken = await MockToken.new({ from: accounts[0] });
-  const baseToken = await MockToken.new({ from: accounts[0] });
+  const mockToken = await MockToken.new(tokenDecimals, { from: accounts[0] });
+  const baseToken = await MockToken.new(tokenDecimals, { from: accounts[0] });
 
   const mockUtilityToken = await MockUtilityToken.new(
     mockToken.address,
     '',
     '',
-    18,
+    tokenDecimals,
     organization.address,
     { from: owner },
   );

--- a/proof_generation/main.sh
+++ b/proof_generation/main.sh
@@ -3,7 +3,7 @@
 PROJECT_NAME='mosaic_proof_generator'
 
 docker run --name mosaic -it -d -p 8546:8545 augurproject/dev-node-geth:v1.8.18
-truffle --network integration_origin test generator.js
+./node_modules/.bin/truffle --network integration_origin test proof_generation/generator.js
 TEST_STATUS=$?
 docker stop mosaic
 docker rm mosaic

--- a/test/core/mosaic_core/verify_vote.js
+++ b/test/core/mosaic_core/verify_vote.js
@@ -20,6 +20,7 @@
 
 const BN = require('bn.js');
 const web3 = require('../../test_lib/web3.js');
+const config = require('../../test_lib/config.js');
 
 const EventsDecoder = require('../../test_lib/event_decoder.js');
 const Utils = require('../../test_lib/utils.js');
@@ -99,7 +100,7 @@ contract('MosaicCore.verifyVote()', async (accounts) => {
     requiredWeight = new BN(21400);
 
     [tokenDeployer] = accounts;
-    erc20 = await MockToken.new({ from: tokenDeployer });
+    erc20 = await MockToken.new(config.decimals, { from: tokenDeployer });
 
     mosaicCore = await MosaicCore.new(
       auxiliaryCoreIdentifier,
@@ -329,7 +330,7 @@ contract('MosaicCore.verifyVote() [commit meta-block]', async (accounts) => {
   beforeEach(async () => {
     [auxiliaryCoreIdentifier] = accounts;
     [tokenDeployer] = accounts;
-    erc20 = await MockToken.new({ from: tokenDeployer });
+    erc20 = await MockToken.new(config.decimals, { from: tokenDeployer });
 
     mosaicCore = await MosaicCore.new(
       auxiliaryCoreIdentifier,

--- a/test/core/stake/TestStake.sol
+++ b/test/core/stake/TestStake.sol
@@ -41,7 +41,7 @@ contract TestStake {
     function beforeEach() external {
         uint256 minimumWeight = 1;
 
-        mockToken = new MockToken();
+        mockToken = new MockToken(18);
         stake = new Stake(
             address(mockToken),
             address(this),

--- a/test/core/stake/close_meta_block.js
+++ b/test/core/stake/close_meta_block.js
@@ -19,6 +19,7 @@
 // ----------------------------------------------------------------------------
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const Events = require('../../test_lib/event_decoder.js');
 const StakeUtils = require('./helpers/stake_utils.js');
 const Utils = require('../../test_lib/utils.js');
@@ -33,7 +34,7 @@ contract('Stake.closeMetaBlock()', async (accounts) => {
   let stake;
 
   beforeEach(async () => {
-    token = await MockToken.new();
+    token = await MockToken.new(config.decimals);
     stake = await Stake.new(token.address, mosaicCoreAccount, minimumWeight);
     await StakeUtils.initializeStake(
       stake,

--- a/test/core/stake/deposit.js
+++ b/test/core/stake/deposit.js
@@ -19,6 +19,7 @@
 // ----------------------------------------------------------------------------
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const Events = require('../../test_lib/event_decoder.js');
 const StakeUtils = require('./helpers/stake_utils.js');
 const Utils = require('../../test_lib/utils.js');
@@ -33,7 +34,7 @@ contract('Stake.deposit()', async (accounts) => {
   let stake;
 
   beforeEach(async () => {
-    token = await MockToken.new();
+    token = await MockToken.new(config.decimals);
     stake = await Stake.new(token.address, mosaicCoreAccount, minimumWeight);
     await StakeUtils.initializeStake(
       stake,

--- a/test/core/stake/initialize.js
+++ b/test/core/stake/initialize.js
@@ -20,6 +20,7 @@
 
 const BN = require('bn.js');
 const StakeUtils = require('./helpers/stake_utils.js');
+const config = require('../../test_lib/config.js');
 const Utils = require('../../test_lib/utils.js');
 
 const MockToken = artifacts.require('MockToken');
@@ -37,7 +38,7 @@ contract('Stake.initialize()', async (accounts) => {
   let initialStakes;
 
   beforeEach(async () => {
-    token = await MockToken.new({ from: tokenDeployer });
+    token = await MockToken.new(config.decimals, { from: tokenDeployer });
     stake = await Stake.new(token.address, mosaicCoreAccount, minimumWeight);
 
     initialDepositors = [accounts[2], accounts[3], accounts[4]];

--- a/test/core/stake/total_weight_at_height.js
+++ b/test/core/stake/total_weight_at_height.js
@@ -19,6 +19,7 @@
 // ----------------------------------------------------------------------------
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const StakeUtils = require('./helpers/stake_utils.js');
 
 const MockToken = artifacts.require('MockToken');
@@ -31,7 +32,7 @@ contract('Stake.totalWeightAtHeight()', async (accounts) => {
   let stake;
 
   beforeEach(async () => {
-    token = await MockToken.new();
+    token = await MockToken.new(config.decimals);
     stake = await Stake.new(token.address, mosaicCoreAccount, minimumWeight);
     await StakeUtils.initializeStake(
       stake,

--- a/test/core/stake/weight.js
+++ b/test/core/stake/weight.js
@@ -19,6 +19,7 @@
 // ----------------------------------------------------------------------------
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const StakeUtils = require('./helpers/stake_utils.js');
 
 const MockToken = artifacts.require('MockToken');
@@ -31,7 +32,7 @@ contract('Stake.weight()', async (accounts) => {
   let stake;
 
   beforeEach(async () => {
-    token = await MockToken.new();
+    token = await MockToken.new(config.decimals);
     stake = await Stake.new(token.address, mosaicCoreAccount, minimumWeight);
     await StakeUtils.initializeStake(
       stake,

--- a/test/gateway/EIP20_token_utils.js
+++ b/test/gateway/EIP20_token_utils.js
@@ -21,6 +21,7 @@
 
 const Assert = require('assert');
 const BN = require('bn.js');
+const config = require('../test_lib/config.js');
 const web3 = require('../test_lib/web3.js');
 
 const EIP20Token = artifacts.require('MockEIP20Token');
@@ -48,9 +49,12 @@ const assertTransferEvent = (
 
 // / @dev Deploy
 module.exports.deployEIP20Token = async (artifacts, accounts) => {
-  const token = await EIP20Token.new('SYMBOL', 'Name', 18, {
-    from: accounts[0],
-  });
+  const token = await EIP20Token.new(
+    'SYMBOL',
+    'Name',
+    config.decimals,
+    { from: accounts[0] },
+  );
 
   return {
     token,

--- a/test/gateway/eip20_cogateway/confirm_revert_stake_intent.js
+++ b/test/gateway/eip20_cogateway/confirm_revert_stake_intent.js
@@ -21,6 +21,7 @@
 const EIP20CoGateway = artifacts.require('TestEIP20CoGateway');
 const UtilityToken = artifacts.require('MockUtilityToken');
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const Utils = require('./../../test_lib/utils');
 const CoGatewayUtils = require('./helpers/co_gateway_utils.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
@@ -55,7 +56,7 @@ contract('EIP20CoGateway.confirmRevertStakeIntent() ', (accounts) => {
       accounts[9],
       'Dummy', // Name
       'Dummy', // Symbol
-      18, // Decimal
+      config.decimals,
       organization,
       { from: owner },
     );

--- a/test/gateway/eip20_cogateway/confirm_stake_intent.js
+++ b/test/gateway/eip20_cogateway/confirm_stake_intent.js
@@ -21,6 +21,7 @@
 const CoGateway = artifacts.require('TestEIP20CoGateway');
 const Token = artifacts.require('MockUtilityToken');
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const Utils = require('./../../test_lib/utils');
 const StubDataWithNonceOne = require('../../data/stake_progressed_0');
 const StubDataWithNonceTwo = require('../../data/stake_progressed_1');
@@ -176,7 +177,7 @@ contract('EIP20CoGateway.confirmStakeIntent() ', (accounts) => {
       valueTokenAddress,
       '',
       '',
-      18,
+      config.decimals,
       organizationAddress,
       { from: sender },
     );

--- a/test/gateway/eip20_cogateway/constructor.js
+++ b/test/gateway/eip20_cogateway/constructor.js
@@ -19,6 +19,7 @@
 // ----------------------------------------------------------------------------
 
 const CoGateway = artifacts.require('EIP20CoGateway');
+const config = require('../../test_lib/config.js');
 const MockToken = artifacts.require('MockToken');
 const MockOrganization = artifacts.require('MockOrganization.sol');
 
@@ -42,8 +43,8 @@ contract('EIP20CoGateway.constructor() ', (accounts) => {
   const burner = NullAddress;
 
   beforeEach(async () => {
-    valueToken = await MockToken.new();
-    utilityToken = await MockToken.new();
+    valueToken = await MockToken.new(config.decimals);
+    utilityToken = await MockToken.new(config.decimals);
     dummyStateRootProvider = accounts[1];
     bountyAmount = new BN(100);
     maxStorageRootItems = new BN(25);

--- a/test/gateway/eip20_cogateway/progress_redeem.js
+++ b/test/gateway/eip20_cogateway/progress_redeem.js
@@ -23,6 +23,7 @@ const MockUtilityToken = artifacts.require('MockUtilityToken');
 
 const BN = require('bn.js');
 
+const config = require('../../test_lib/config.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../test_lib/utils.js');
 const web3 = require('../../test_lib/web3.js');
@@ -58,7 +59,7 @@ contract('EIP20CoGateway.progressRedeem() ', (accounts) => {
       accounts[9],
       '',
       '',
-      18,
+      config.decimals,
       accounts[2], // organization,
       { from: owner },
     );

--- a/test/gateway/eip20_cogateway/progress_redeem_with_proof.js
+++ b/test/gateway/eip20_cogateway/progress_redeem_with_proof.js
@@ -22,7 +22,7 @@ const EIP20CoGateway = artifacts.require('TestEIP20CoGateway');
 const MockUtilityToken = artifacts.require('MockUtilityToken');
 const BN = require('bn.js');
 
-const config = require('../../test_lib/config..js');
+const config = require('../../test_lib/config.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../test_lib/utils.js');
 const web3 = require('../../test_lib/web3.js');

--- a/test/gateway/eip20_cogateway/progress_redeem_with_proof.js
+++ b/test/gateway/eip20_cogateway/progress_redeem_with_proof.js
@@ -22,6 +22,7 @@ const EIP20CoGateway = artifacts.require('TestEIP20CoGateway');
 const MockUtilityToken = artifacts.require('MockUtilityToken');
 const BN = require('bn.js');
 
+const config = require('../../test_lib/config..js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../test_lib/utils.js');
 const web3 = require('../../test_lib/web3.js');
@@ -77,14 +78,13 @@ contract('EIP20CoGateway.progressRedeemWithProof() ', (accounts) => {
     const valueTokenAddress = accounts[9];
     const symbol = 'DMY';
     const tokenName = 'Dummy token';
-    const tokenDecimal = 18;
     const organization = accounts[2];
 
     utilityToken = await MockUtilityToken.new(
       valueTokenAddress,
       symbol,
       tokenName,
-      tokenDecimal,
+      config.decimals,
       organization,
     );
 

--- a/test/gateway/eip20_cogateway/progress_revert_redeem.js
+++ b/test/gateway/eip20_cogateway/progress_revert_redeem.js
@@ -22,6 +22,7 @@ const EIP20CoGateway = artifacts.require('TestEIP20CoGateway');
 const MockUtilityToken = artifacts.require('MockUtilityToken');
 const BN = require('bn.js');
 
+const config = require('../../test_lib/config.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../test_lib/utils.js');
 const web3 = require('../../test_lib/web3.js');
@@ -64,7 +65,6 @@ contract('EIP20CoGateway.progressRevertRedeem()', (accounts) => {
       messageStatus: MessageStatusEnum.Declared,
     };
 
-    const decimal = 18;
     const token = accounts[9];
     const symbol = 'DUM';
     const name = 'Dummy';
@@ -73,7 +73,7 @@ contract('EIP20CoGateway.progressRevertRedeem()', (accounts) => {
       token,
       symbol,
       name,
-      decimal,
+      config.decimals,
       organization,
       { from: owner },
     );

--- a/test/gateway/eip20_cogateway/redeem.js
+++ b/test/gateway/eip20_cogateway/redeem.js
@@ -21,6 +21,7 @@
 const BN = require('bn.js');
 
 const CoGatewayUtils = require('./helpers/co_gateway_utils.js');
+const config = require('../../test_lib/config.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../test_lib/utils');
 const web3 = require('../../test_lib/web3');
@@ -63,7 +64,7 @@ contract('EIP20CoGateway.redeem()', (accounts) => {
       burner,
     ] = accounts;
 
-    utilityToken = await MockToken.new({ from: owner });
+    utilityToken = await MockToken.new(config.decimals, { from: owner });
     bountyAmount = new BN(100);
     redeemerBalance = new BN(100000);
 

--- a/test/gateway/eip20_cogateway/revert_redeem.js
+++ b/test/gateway/eip20_cogateway/revert_redeem.js
@@ -22,6 +22,7 @@ const EIP20CoGateway = artifacts.require('TestEIP20CoGateway');
 const BN = require('bn.js');
 
 const MockUtilityToken = artifacts.require('MockUtilityToken');
+const config = require('../../test_lib/config.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../test_lib/utils.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
@@ -53,7 +54,7 @@ contract('EIP20CoGateway.revertRedeem()', (accounts) => {
       constructorParams.valueToken, // Token address.
       'DMY', // Symbol.
       'Dummy token', // Token name.
-      18, // Token decimal.
+      config.decimals,
       constructorParams.organization, // Organisation address.
       { from: constructorParams.owner },
     );

--- a/test/gateway/eip20_gateway/confirm_revert_redeem_intent.js
+++ b/test/gateway/eip20_gateway/confirm_revert_redeem_intent.js
@@ -22,6 +22,7 @@ const Gateway = artifacts.require('./TestEIP20Gateway.sol');
 const MockToken = artifacts.require('MockToken');
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../../test/test_lib/utils');
@@ -56,8 +57,8 @@ contract('EIP20Gateway.confirmRevertRedeemIntent()', (accounts) => {
 
   beforeEach(async () => {
     redeemRequest = StubData.co_gateway.redeem.params;
-    mockToken = await MockToken.new({ from: accounts[0] });
-    baseToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
+    baseToken = await MockToken.new(config.decimals, { from: accounts[0] });
 
     const organizationAddress = accounts[3];
     const coreAddress = accounts[5];

--- a/test/gateway/eip20_gateway/constructor.js
+++ b/test/gateway/eip20_gateway/constructor.js
@@ -23,6 +23,7 @@ const MockToken = artifacts.require('MockToken');
 const MockOrganization = artifacts.require('MockOrganization.sol');
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const Utils = require('./../../test_lib/utils');
 
 const NullAddress = Utils.NULL_ADDRESS;
@@ -41,8 +42,8 @@ contract('EIP20Gateway.constructor() ', (accounts) => {
   const burner = NullAddress;
 
   beforeEach(async () => {
-    mockToken = await MockToken.new();
-    baseToken = await MockToken.new();
+    mockToken = await MockToken.new(config.decimals);
+    baseToken = await MockToken.new(config.decimals);
     dummyRootProviderAddress = accounts[1];
     bountyAmount = new BN(100);
     maxStorageRootItems = new BN(25);

--- a/test/gateway/eip20_gateway/progress_revert_stake.js
+++ b/test/gateway/eip20_gateway/progress_revert_stake.js
@@ -23,6 +23,7 @@ const MockOrganization = artifacts.require('MockOrganization.sol');
 const MockToken = artifacts.require('MockToken');
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../../test/test_lib/utils');
@@ -72,8 +73,8 @@ contract('EIP20Gateway.progressRevertStake()', (accounts) => {
   };
 
   beforeEach(async () => {
-    mockToken = await MockToken.new({ from: accounts[0] });
-    baseToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
+    baseToken = await MockToken.new(config.decimals, { from: accounts[0] });
 
     const owner = accounts[2];
     const worker = accounts[7];

--- a/test/gateway/eip20_gateway/progress_stake.js
+++ b/test/gateway/eip20_gateway/progress_stake.js
@@ -23,6 +23,7 @@ const MockOrganization = artifacts.require('MockOrganization.sol');
 const MockToken = artifacts.require('MockToken');
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../../test/test_lib/utils');
@@ -52,8 +53,8 @@ contract('EIP20Gateway.progressStake()', (accounts) => {
   const { MessageStatusEnum } = messageBus;
 
   beforeEach(async () => {
-    mockToken = await MockToken.new({ from: accounts[0] });
-    baseToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
+    baseToken = await MockToken.new(config.decimals, { from: accounts[0] });
 
     const owner = accounts[2];
     const worker = accounts[7];

--- a/test/gateway/eip20_gateway/progress_stake_with_proof.js
+++ b/test/gateway/eip20_gateway/progress_stake_with_proof.js
@@ -23,6 +23,7 @@ const MockOrganization = artifacts.require('MockOrganization.sol');
 const MockToken = artifacts.require('MockToken');
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../../test/test_lib/utils');
@@ -115,8 +116,8 @@ contract('EIP20Gateway.progressStakeWithProof()', (accounts) => {
 
 
   beforeEach(async () => {
-    mockToken = await MockToken.new({ from: accounts[0] });
-    baseToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
+    baseToken = await MockToken.new(config.decimals, { from: accounts[0] });
 
     const owner = accounts[2];
     const worker = accounts[7];

--- a/test/gateway/eip20_gateway/progress_unstake.js
+++ b/test/gateway/eip20_gateway/progress_unstake.js
@@ -22,6 +22,7 @@ const Gateway = artifacts.require('./TestEIP20Gateway.sol');
 const MockToken = artifacts.require('MockToken');
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../../test/test_lib/utils');
@@ -69,8 +70,8 @@ contract('EIP20Gateway.progressUnstake()', (accounts) => {
   };
 
   beforeEach(async () => {
-    mockToken = await MockToken.new({ from: accounts[0] });
-    baseToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
+    baseToken = await MockToken.new(config.decimals, { from: accounts[0] });
 
     const organizationAddress = accounts[3];
     const coreAddress = accounts[5];

--- a/test/gateway/eip20_gateway/progress_unstake_with_proof.js
+++ b/test/gateway/eip20_gateway/progress_unstake_with_proof.js
@@ -22,6 +22,7 @@ const Gateway = artifacts.require('./TestEIP20Gateway.sol');
 const MockToken = artifacts.require('MockToken');
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../../test/test_lib/utils');
@@ -56,8 +57,8 @@ contract('EIP20Gateway.progressUnstakeWithProof()', (accounts) => {
 
   beforeEach(async () => {
     redeemRequest = StubData.co_gateway.redeem.params;
-    mockToken = await MockToken.new({ from: accounts[0] });
-    baseToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
+    baseToken = await MockToken.new(config.decimals, { from: accounts[0] });
 
     const organizationAddress = accounts[3];
     const coreAddress = accounts[5];

--- a/test/gateway/eip20_gateway/revert_stake.js
+++ b/test/gateway/eip20_gateway/revert_stake.js
@@ -23,6 +23,7 @@ const MockToken = artifacts.require('MockToken');
 
 const BN = require('bn.js');
 
+const config = require('../../test_lib/config.js');
 const EventDecoder = require('../../test_lib/event_decoder.js');
 const messageBus = require('../../test_lib/message_bus.js');
 const Utils = require('../../../test/test_lib/utils');
@@ -50,8 +51,8 @@ contract('EIP20Gateway.revertStake()', (accounts) => {
   };
 
   beforeEach(async () => {
-    mockToken = await MockToken.new({ from: accounts[0] });
-    baseToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
+    baseToken = await MockToken.new(config.decimals, { from: accounts[0] });
 
     const organization = accounts[1];
     const coreAddress = accounts[5];

--- a/test/gateway/eip20_gateway/stake.js
+++ b/test/gateway/eip20_gateway/stake.js
@@ -19,6 +19,7 @@
 // ----------------------------------------------------------------------------
 
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 const utils = require('../../test_lib/utils');
 const GatewayUtils = require('./helpers/gateway_utils');
 const messageBus = require('../../test_lib/message_bus.js');
@@ -110,8 +111,8 @@ contract('EIP20Gateway.stake() ', (accounts) => {
   beforeEach(async () => {
     [core, stakerAddress, beneficiary, coGateway, organization] = accounts;
 
-    mockToken = await MockToken.new();
-    baseToken = await MockToken.new();
+    mockToken = await MockToken.new(config.decimals);
+    baseToken = await MockToken.new(config.decimals);
     mockOrganization = await MockOrganization.new(organization, organization);
 
     bountyAmount = new BN(100);

--- a/test/gateway/mock_token.js
+++ b/test/gateway/mock_token.js
@@ -22,6 +22,7 @@
 const BN = require('bn.js');
 const web3 = require('../test_lib/web3.js');
 
+const config = require('../test_lib/config.js');
 const Utils = require('../test_lib/utils.js');
 const EIP20TokenUtils = require('./EIP20_token_utils.js');
 const EventsDecoder = require('../test_lib/event_decoder.js');
@@ -66,7 +67,7 @@ const MockToken = artifacts.require('./MockToken.sol');
 contract('MockToken', (accounts) => {
   const SYMBOL = 'MOCK';
   const NAME = 'Mock Token';
-  const DECIMALS = 18;
+  const DECIMALS = config.decimals;
   const TOTAL_SUPPLY = web3.utils.toWei(new BN('800000000'), 'ether');
 
   const ST10000 = web3.utils.toWei(new BN('10000'), 'ether');
@@ -76,7 +77,7 @@ contract('MockToken', (accounts) => {
   const ST1 = web3.utils.toWei(new BN('1'), 'ether');
 
   async function createToken() {
-    return MockToken.new();
+    return MockToken.new(config.decimals);
   }
 
   describe('Basic properties', async () => {

--- a/test/gateway/mock_token_utils.js
+++ b/test/gateway/mock_token_utils.js
@@ -20,10 +20,11 @@
 // ----------------------------------------------------------------------------
 
 const MockToken = artifacts.require('./MockToken.sol');
+const config = require('../test_lib/config.js');
 
 // / @dev Deploy
 module.exports.deployMockToken = async (artifacts, accounts) => {
-  const token = await MockToken.new({ from: accounts[0], gas: 3500000 });
+  const token = await MockToken.new(config.decimals, { from: accounts[0], gas: 3500000 });
 
   return {
     token,

--- a/test/gateway/simple_stake/constructor.js
+++ b/test/gateway/simple_stake/constructor.js
@@ -22,6 +22,7 @@ const SimpleStake = artifacts.require('./SimpleStake.sol');
 const MockToken = artifacts.require('./MockToken.sol');
 
 const web3 = require('../../../test/test_lib/web3.js');
+const config = require('../../test_lib/config.js');
 const Utils = require('../../../test/test_lib/utils.js');
 
 const zeroAddress = Utils.NULL_ADDRESS;
@@ -29,7 +30,7 @@ contract('SimpleStake.constructor()', (accounts) => {
   const gateway = accounts[4];
   let mockToken;
   beforeEach(async () => {
-    mockToken = await MockToken.new({ from: accounts[0] });
+    mockToken = await MockToken.new(config.decimals, { from: accounts[0] });
   });
 
   it('should pass with correct parameters', async () => {

--- a/test/gateway/simple_stake/get_total_stake.js
+++ b/test/gateway/simple_stake/get_total_stake.js
@@ -21,13 +21,14 @@
 const SimpleStake = artifacts.require('./SimpleStake.sol');
 const MockToken = artifacts.require('./MockToken.sol');
 const BN = require('bn.js');
+const config = require('../../test_lib/config.js');
 
 contract('SimpleStake.getTotalStake()', (accounts) => {
   const gateway = accounts[4];
   let token;
   let simpleStake;
   beforeEach(async () => {
-    token = await MockToken.new({ from: accounts[0] });
+    token = await MockToken.new(config.decimals, { from: accounts[0] });
 
     simpleStake = await SimpleStake.new(token.address, gateway, {
       from: accounts[0],

--- a/test/gateway/simple_stake/release_to.js
+++ b/test/gateway/simple_stake/release_to.js
@@ -22,6 +22,7 @@ const SimpleStake = artifacts.require('./SimpleStake.sol');
 const MockToken = artifacts.require('./MockToken.sol');
 const BN = require('bn.js');
 
+const config = require('../../test_lib/config.js');
 const Utils = require('../../../test/test_lib/utils.js');
 const Events = require('../../test_lib/event_decoder.js');
 
@@ -30,7 +31,7 @@ contract('SimpleStake.releaseTo()', (accounts) => {
   let token;
   let simpleStake;
   beforeEach(async () => {
-    token = await MockToken.new({ from: accounts[0] });
+    token = await MockToken.new(config.decimals, { from: accounts[0] });
     const amount = new BN(100);
 
     simpleStake = await SimpleStake.new(token.address, gateway, {

--- a/test/gateway/staker_proxy/transfer_token.js
+++ b/test/gateway/staker_proxy/transfer_token.js
@@ -22,6 +22,7 @@
 
 const MockToken = artifacts.require('./MockToken.sol');
 const StakerProxy = artifacts.require('./StakerProxy.sol');
+const config = require('../../test_lib/config');
 const Utils = require('../../test_lib/utils');
 
 contract('StakerProxy.transferToken()', (accounts) => {
@@ -39,7 +40,7 @@ contract('StakerProxy.transferToken()', (accounts) => {
   });
 
   it('should send the tokens to the desired recipient', async () => {
-    const mockToken = await MockToken.new({ from: deployer });
+    const mockToken = await MockToken.new(config.decimals, { from: deployer });
     await mockToken.transfer(
       stakerProxy.address,
       transferValue,

--- a/test/test_lib/config.js
+++ b/test/test_lib/config.js
@@ -1,5 +1,3 @@
-pragma solidity ^0.5.0;
-
 // Copyright 2019 OpenST Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +11,20 @@ pragma solidity ^0.5.0;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // ----------------------------------------------------------------------------
-// Contracts: MockTokenConfig 
 //
 // http://www.simpletoken.org/
 //
 // ----------------------------------------------------------------------------
 
+'use strict';
 
-contract MockTokenConfig {
+/** Test wide configuration for various tests. */
+const config = {
+  get decimals() {
+    return 18;
+  },
+};
 
-    string  public constant TOKEN_SYMBOL   = "MOCK";
-    string  public constant TOKEN_NAME     = "Mock Token";
-}
+module.exports = config;

--- a/test/test_lib/config.js
+++ b/test/test_lib/config.js
@@ -20,10 +20,20 @@
 
 'use strict';
 
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { env } = require('process');
+
 /** Test wide configuration for various tests. */
 const config = {
+  /** Defaults to 18. Can be overriden with the environment variable OPENST_DECIMALS. */
   get decimals() {
-    return 18;
+    let decimals = 18;
+
+    if (env.OPENST_DECIMALS) {
+      decimals = Number.parseInt(env.OPENST_DECIMALS, 10);
+    }
+
+    return decimals;
   },
 };
 

--- a/tools/test_range.sh
+++ b/tools/test_range.sh
@@ -28,23 +28,34 @@
 # ```bash
 # npm run test:range -- 12 18
 # ```
+#
+# You can provide only one argument and the tests will run for that specific
+# decimal.
 ###
 
 echo ""
 
-if [ $# -ne 2 ];
+if [ $# -ne 1 ] && [ $# -ne 2 ];
 then
     echo "Wrong number of parameters given."
     echo "Run with two arguments: start and end of range inclusive."
     echo "Example:"
     echo "npm run test:range -- 16 20"
     echo ""
+    echo "If you provide only one argument, the tests will be run for that value."
+    echo ""
     exit 1
 fi
 
 # Start and end values should be provided on the command line.
 START=$1
-END=$2
+
+if [ $# -eq 1 ];
+then
+    END=$START
+else
+    END=$2
+fi
 
 for DECIMALS in $(seq "${START}" "${END}");
 do

--- a/tools/test_range.sh
+++ b/tools/test_range.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright 2019 OpenST Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ----------------------------------------------------------------------------
+#
+# http://www.simpletoken.org/
+#
+# ----------------------------------------------------------------------------
+
+###
+# Runs tests sequentially for a range of decimal values.
+#
+# Example run with decimals 12 - 18 (inclusive):
+#
+# ```bash
+# npm run test:range -- 12 18
+# ```
+###
+
+echo ""
+
+if [ $# -ne 2 ];
+then
+    echo "Wrong number of parameters given."
+    echo "Run with two arguments: start and end of range inclusive."
+    echo "Example:"
+    echo "npm run test:range -- 16 20"
+    echo ""
+    exit 1
+fi
+
+# Start and end values should be provided on the command line.
+START=$1
+END=$2
+
+for DECIMALS in $(seq "${START}" "${END}");
+do
+    echo "### Running tests with ${DECIMALS} decimals."
+    export OPENST_DECIMALS=$DECIMALS
+    npm test || exit 2
+done
+
+echo ""
+echo "### Done"
+echo ""

--- a/tools/test_range.sh
+++ b/tools/test_range.sh
@@ -33,6 +33,39 @@
 # decimal.
 ###
 
+# Tracking the exit code to run further tests if they fail for a spcefic decimal.
+EXIT_CODE=0
+
+# Tracking failed decimals for error output.
+FAILED_DECIMALS=""
+
+function handle_error {
+    # On first iteration, no extra comma
+    if [ $EXIT_CODE -eq 0 ];
+    then
+        FAILED_DECIMALS="$1"
+    else
+        FAILED_DECIMALS="${FAILED_DECIMALS}, $1"
+    fi
+    EXIT_CODE=1
+}
+
+function handle_exit {
+    if [ $EXIT_CODE -ne 0 ];
+    then
+        echo ""
+        echo "### Errors for the following decimals:"
+        echo "${FAILED_DECIMALS}"
+        echo ""
+    else
+        echo ""
+        echo "### Done"
+        echo ""
+    fi
+
+    exit $EXIT_CODE
+}
+
 echo ""
 
 if [ $# -ne 1 ] && [ $# -ne 2 ];
@@ -61,9 +94,8 @@ for DECIMALS in $(seq "${START}" "${END}");
 do
     echo "### Running tests with ${DECIMALS} decimals."
     export OPENST_DECIMALS=$DECIMALS
-    npm test || exit 2
+    npm test || handle_error $DECIMALS
 done
 
-echo ""
-echo "### Done"
-echo ""
+handle_exit
+


### PR DESCRIPTION
* Added config in tests to get configured decimals (default or `env` override).
* Updated `MockToken` to take decimals as constructor argument.
* Updated all instantiations of various tokens in unit tests to use decimals from config.
* Updated proof generator to use 18 decimals (it uses mock token).
* Added new script `test:range`. Example: `npm run test:range -- 16 18`

Fixes #735 