### PR TITLE
Mutex refactoring and nonce removal check from StakerProxy.stake()

### DIFF
--- a/contracts/gateway/OSTComposer.sol
+++ b/contracts/gateway/OSTComposer.sol
@@ -271,7 +271,6 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
         bytes32 _hashLock
     )
         external
-        mutex
         onlyWorker
         returns(bytes32 messageHash_)
     {
@@ -280,15 +279,14 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
             stakeRequest.staker != address(0),
             "Stake request must exists."
         );
+        delete stakeRequestHashes[stakeRequest.staker][address(stakeRequest.gateway)];
+        delete stakeRequests[_stakeRequestHash];
 
         EIP20GatewayInterface gateway = stakeRequest.gateway;
 
         StakerProxy stakerProxy = stakerProxies[stakeRequest.staker];
 
         activeStakeRequestCount[stakeRequest.staker] = activeStakeRequestCount[stakeRequest.staker].sub(1);
-
-        delete stakeRequestHashes[stakeRequest.staker][address(stakeRequest.gateway)];
-        delete stakeRequests[_stakeRequestHash];
 
         EIP20Interface valueToken = gateway.valueToken();
         require(
@@ -324,7 +322,6 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
         bytes32 _stakeRequestHash
     )
         external
-        mutex
     {
         address staker = stakeRequests[_stakeRequestHash].staker;
         require(
@@ -347,7 +344,6 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
         bytes32 _stakeRequestHash
     )
         external
-        mutex
         onlyWorker
     {
         address staker = stakeRequests[_stakeRequestHash].staker;

--- a/test/gateway/staker_proxy/stake.js
+++ b/test/gateway/staker_proxy/stake.js
@@ -171,21 +171,4 @@ contract('StakerProxy.stake()', (accounts) => {
       'This function can only be called by the composer.',
     );
   });
-
-  it('should fail if nonces do not match', async () => {
-    const wrongNonce = nonce - 5;
-    await Utils.expectRevert(
-      stakerProxy.stake.call(
-        amount,
-        beneficiary,
-        gasPrice,
-        gasLimit,
-        wrongNonce,
-        hashLock,
-        spyGateway.address,
-        { from: composer },
-      ),
-      'Nonce must match nonce expected by gateway.',
-    );
-  });
 });


### PR DESCRIPTION
PR covers below:
- Remove a check for a valid nonce from StakerProxy.stake()
- Replace StakerProxy's own implementation of a mutex by inheriting from Mutex contract.
- Remove mutex from OSTComposer::acceptStakeRequest function.
- Remove mutex from OSTComposer::revokeStakeRequest and OSTComposer::rejectStakeRequest

Fixes #763 