### PR TITLE
Destructing staker proxy via ost composer contract

### DIFF
--- a/contracts/gateway/OSTComposer.sol
+++ b/contracts/gateway/OSTComposer.sol
@@ -375,7 +375,7 @@ contract OSTComposer is Organized, Mutex {
         StakerProxy stakerProxy = stakerProxies[msg.sender];
         require(
             address(stakerProxy) != address(0),
-            "Staker proxy doesnot exist for this owner."
+            "Staker proxy does not exist for the caller."
         );
         // Resetting the proxy address of the staker.
         delete stakerProxies[msg.sender];

--- a/contracts/gateway/OSTComposer.sol
+++ b/contracts/gateway/OSTComposer.sol
@@ -25,7 +25,6 @@ import "./StakerProxy.sol";
 import "./EIP20GatewayInterface.sol";
 import "../lib/EIP20Interface.sol";
 import "../lib/Mutex.sol";
-import "./ComposerInterface.sol";
 
 /**
  * @title OSTComposer implements Organized contract. Reentrancy is prevented
@@ -33,7 +32,7 @@ import "./ComposerInterface.sol";
  *
  * @notice It facilitates the staker to get the OSTPrime on sidechains.
  */
-contract OSTComposer is Organized, Mutex, ComposerInterface {
+contract OSTComposer is Organized, Mutex {
 
     /* Constants */
 
@@ -365,19 +364,22 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
     }
 
     /**
-     * @notice It can only be called by StakerProxy contract of the staker. It
-     *         deletes the StakerProxy contract of the staker.
-     *
-     * @param _owner Owner of the StakerProxy contract.
+     * @notice It can only be called by owner of the staker proxy. It
+     *         deletes the StakerProxy contract of the staker and calls self
+     *         destruct on StakerProxy contract.
      */
-    function removeStakerProxy(
-        address _owner
-    )
+    function destructStakerProxy()
         external
-        onlyStakerProxy(_owner)
     {
+
+        StakerProxy stakerProxy = stakerProxies[msg.sender];
+        require(
+            address(stakerProxy) != address(0),
+            "Staker proxy doesnot exist for this owner."
+        );
         // Resetting the proxy address of the staker.
-        delete stakerProxies[_owner];
+        delete stakerProxies[msg.sender];
+        stakerProxy.selfDestruct();
     }
 
 

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -20,7 +20,6 @@ pragma solidity ^0.5.0;
 //
 // ----------------------------------------------------------------------------
 
-import "./ComposerInterface.sol";
 import "./EIP20GatewayInterface.sol";
 import "../lib/EIP20Interface.sol";
 import "../lib/Mutex.sol";
@@ -38,7 +37,7 @@ contract StakerProxy is Mutex {
     /* Storage */
 
     /** The composer that deployed this contract. */
-    ComposerInterface public composer;
+    address public composer;
 
     /** The composer deployed the StakerProxy on behalf of the owner. */
     address payable public owner;
@@ -70,13 +69,12 @@ contract StakerProxy is Mutex {
     /* Special Functions */
 
     /**
-     * @notice Must be constructed by a contract that implements the
-     *         `ComposerInterface`.
+     * @notice Must be constructed by a composer contract.
      *
      * @param _owner The owner that this proxy is deployed for.
      */
     constructor(address payable _owner) public {
-        composer = ComposerInterface(msg.sender);
+        composer = msg.sender;
         owner = _owner;
     }
 
@@ -160,9 +158,7 @@ contract StakerProxy is Mutex {
      *         to transfer all remaining token balance of this contract before
      *         calling this method.
      */
-    function selfDestruct() external onlyOwner {
-        composer.removeStakerProxy(owner);
-
+    function selfDestruct() external onlyComposer {
         selfdestruct(owner);
     }
 

--- a/contracts/test/gateway/MockStakerProxy.sol
+++ b/contracts/test/gateway/MockStakerProxy.sol
@@ -21,7 +21,8 @@ pragma solidity ^0.5.0;
 // ----------------------------------------------------------------------------
 
 /**
- * @title MockStakerProxy is a contract used for unit testing of ostComposer method `destructStakerProxy`.
+ * @title MockStakerProxy is a contract used for unit testing of ostComposer
+ *        method `destructStakerProxy`.
  */
 contract MockStakerProxy {
 
@@ -38,7 +39,8 @@ contract MockStakerProxy {
     }
 
     /**
-     * @notice Mock method called from ost composer during unit testing of `destructStakerProxy`.
+     * @notice Mock method called from ost composer during unit testing of
+     *         `destructStakerProxy`.
      */
     function selfDestruct() external {
         selfDestruted = true;

--- a/contracts/test/gateway/MockStakerProxy.sol
+++ b/contracts/test/gateway/MockStakerProxy.sol
@@ -20,13 +20,27 @@ pragma solidity ^0.5.0;
 //
 // ----------------------------------------------------------------------------
 
+/**
+ * @title MockStakerProxy is a contract used for unit testing of ostComposer method `destructStakerProxy`.
+ */
+contract MockStakerProxy {
 
-interface ComposerInterface {
+    /* Storage */
+
+    /** Flag to assert if self destruct is called. */
+    bool public selfDestruted;
+
+
+    /* Special Functions */
+
+    constructor () public {
+        selfDestruted = false;
+    }
 
     /**
-     * @notice It deletes the StakerProxy contract for the staker.
-     *
-     * @param _owner Owner of the StakerProxy contract.
+     * @notice Mock method called from ost composer during unit testing of `destructStakerProxy`.
      */
-    function removeStakerProxy(address _owner) external;
+    function selfDestruct() external {
+        selfDestruted = true;
+    }
 }

--- a/test/gateway/ost_composer/destruct_staker_proxy.js
+++ b/test/gateway/ost_composer/destruct_staker_proxy.js
@@ -68,7 +68,7 @@ contract('OSTComposer.destructStakerProxy() ', (accounts) => {
       ostComposer.destructStakerProxy(
         { from: nonProxy },
       ),
-      'Staker proxy doesnot exist for this owner.',
+      'Staker proxy does not exist for the caller.',
     );
   });
 });

--- a/test/gateway/staker_proxy/self_destruct.js
+++ b/test/gateway/staker_proxy/self_destruct.js
@@ -1,0 +1,49 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+'use strict';
+
+const StakerProxy = artifacts.require('./StakerProxy.sol');
+const Utils = require('../../test_lib/utils');
+
+contract('StakerProxy.selfDestruct()', (accounts) => {
+  const [composer, owner, anyOtherAddress] = accounts;
+  let stakerProxy;
+
+  beforeEach(async () => {
+    stakerProxy = await StakerProxy.new(
+      owner,
+      { from: composer },
+    );
+  });
+
+  it('should allow self destruct by composer ', async () => {
+    const response = await stakerProxy.selfDestruct({ from: composer });
+
+    assert.strictEqual(response.receipt.status, true, 'Receipt status is unsuccessful');
+  });
+
+  it('should not allow self destruct by  non composer address ', async () => {
+    await Utils.expectRevert(
+      stakerProxy.selfDestruct({ from: anyOtherAddress }),
+      'This function can only be called by the composer.',
+    );
+  });
+});

--- a/test/gateway/staker_proxy/self_destruct.js
+++ b/test/gateway/staker_proxy/self_destruct.js
@@ -38,6 +38,14 @@ contract('StakerProxy.selfDestruct()', (accounts) => {
     const response = await stakerProxy.selfDestruct({ from: composer });
 
     assert.strictEqual(response.receipt.status, true, 'Receipt status is unsuccessful');
+
+    const stakerProxyCode = await web3.eth.getCode(stakerProxy.address);
+
+    assert.strictEqual(
+      stakerProxyCode,
+      '0x',
+      'Staker proxy contract code should be 0x after self destructing',
+    );
   });
 
   it('should not allow self destruct by  non composer address ', async () => {


### PR DESCRIPTION
fixes #771 

This PR updates the flow of self-destructing staker proxy contract. With this PR, staker(owner) can call `destructStakerProxy` on composer contract.

This PR also delete ComposerInterface used in stakerProxy contract as there is no method call from staker proxy to composer.