### PR TITLE
OSTComposer StakeRequest object storage optimization

### DIFF
--- a/contracts/gateway/OSTComposer.sol
+++ b/contracts/gateway/OSTComposer.sol
@@ -249,6 +249,12 @@ contract OSTComposer is Organized, Mutex {
         onlyWorker
         returns(bytes32 messageHash_)
     {
+        StakerProxy stakerProxy = stakerProxies[_staker];
+        require(
+            address(stakerProxy) != address(0),
+            "StakerProxy address is null."
+        );
+
         bytes32 stakeRequestHash = hashStakeRequest(
             _amount,
             _beneficiary,
@@ -264,12 +270,6 @@ contract OSTComposer is Organized, Mutex {
         );
         delete stakeRequestHashes[_staker][address(_gateway)];
         delete stakeRequests[stakeRequestHash];
-
-        StakerProxy stakerProxy = stakerProxies[_staker];
-        require(
-            address(stakerProxy) != address(0),
-            "StakerProxy address is null."
-        );
 
         EIP20Interface valueToken = _gateway.valueToken();
         require(

--- a/contracts/gateway/OSTComposer.sol
+++ b/contracts/gateway/OSTComposer.sol
@@ -71,40 +71,6 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
     );
 
 
-    /* Struct */
-
-    /**
-     * StakeRequest stores the stake amount, beneficiary address, gas price, gas
-     * limit, nonce, staker and gateway address.
-     */
-    struct StakeRequest {
-
-        /** Amount that will be staked. */
-        uint256 amount;
-
-        /**
-         * Address where the utility tokens will be minted in the
-         * auxiliary chain.
-         */
-        address beneficiary;
-
-        /** Gas price that staker is willing to pay. */
-        uint256 gasPrice;
-
-        /** Gas limit that staker is willing to pay. */
-        uint256 gasLimit;
-
-        /** Staker nonce at the gateway. */
-        uint256 nonce;
-
-        /** Address of the staker. */
-        address staker;
-
-        /** Address of the gateway where amount will be staked. */
-        EIP20GatewayInterface gateway;
-    }
-
-
     /* Public Variables */
 
     /* Mapping of staker to gateway to store stake request hash. */
@@ -113,8 +79,8 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
     /* Mapping of staker addresses to their StakerProxy. */
     mapping (address => StakerProxy) public stakerProxies;
 
-    /* Stores all the parameters of stake request based on stake request hash. */
-    mapping (bytes32 => StakeRequest) public stakeRequests;
+    /* Stores boolean based on stake request hash. */
+    mapping (bytes32 => bool) public stakeRequests;
 
 
     /* Modifiers */
@@ -216,15 +182,7 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
             "Incorrect staker nonce."
         );
 
-        stakeRequests[stakeRequestHash_] = StakeRequest({
-            amount: _amount,
-            beneficiary: _beneficiary,
-            gasPrice: _gasPrice,
-            gasLimit: _gasLimit,
-            nonce: _nonce,
-            staker: msg.sender,
-            gateway: _gateway
-        });
+        stakeRequests[stakeRequestHash_] = true;
 
         EIP20Interface valueToken = _gateway.valueToken();
 
@@ -250,57 +208,76 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
      *         Staked amount from composer and bounty amount from facilitator
      *         is then transferred to the StakerProxy contract of the staker.
      *
-     * @param _stakeRequestHash Unique hash for the stake request which is to
-     *                          be Processed.
+     * @param _amount Amount that is to be staked.
+     * @param _beneficiary The address in the auxiliary chain where the utility
+     *                     tokens will be minted.
+     * @param _gasPrice Gas price that staker is ready to pay to get the stake
+     *                  and mint process done.
+     * @param _gasLimit Gas limit that staker is ready to pay.
+     * @param _nonce Staker nonce specific to gateway.
+     * @param _staker StakerProxy contract address of staker.
+     * @param _gateway Address of the gateway to stake.
      * @param _hashLock Hashlock provided by the facilitator.
      *
      * @return messageHash_ Hash unique for each request.
      */
     function acceptStakeRequest(
-        bytes32 _stakeRequestHash,
+        uint256 _amount,
+        address _beneficiary,
+        uint256 _gasPrice,
+        uint256 _gasLimit,
+        uint256 _nonce,
+        address _staker,
+        EIP20GatewayInterface _gateway,
         bytes32 _hashLock
     )
         external
         onlyWorker
         returns(bytes32 messageHash_)
     {
-        StakeRequest memory stakeRequest = stakeRequests[_stakeRequestHash];
+        bytes32 stakeRequestHash = hashStakeRequest(
+            _amount,
+            _beneficiary,
+            _gasPrice,
+            _gasLimit,
+            _nonce,
+            _staker,
+            address(_gateway)
+        );
         require(
-            stakeRequest.staker != address(0),
+            stakeRequests[stakeRequestHash],
             "Stake request must exists."
         );
-        delete stakeRequestHashes[stakeRequest.staker][address(stakeRequest.gateway)];
-        delete stakeRequests[_stakeRequestHash];
+        delete stakeRequestHashes[_staker][address(_gateway)];
+        delete stakeRequests[stakeRequestHash];
 
-        EIP20GatewayInterface gateway = stakeRequest.gateway;
-
-        StakerProxy stakerProxy = stakerProxies[stakeRequest.staker];
+        StakerProxy stakerProxy = stakerProxies[_staker];
         require(
             address(stakerProxy) != address(0),
             "StakerProxy address is null."
         );
 
-        EIP20Interface valueToken = gateway.valueToken();
+        EIP20Interface valueToken = _gateway.valueToken();
         require(
-            valueToken.transfer(address(stakerProxy), stakeRequest.amount),
+            valueToken.transfer(address(stakerProxy), _amount),
             "Staked amount must be transferred to the staker proxy."
         );
 
-        EIP20Interface baseToken = gateway.baseToken();
-        uint256 bounty = gateway.bounty();
+        EIP20Interface baseToken = _gateway.baseToken();
+        uint256 bounty = _gateway.bounty();
         require(
             baseToken.transferFrom(msg.sender, address(stakerProxy), bounty),
             "Bounty amount must be transferred to stakerProxy."
         );
 
         messageHash_ = stakerProxy.stake(
-            stakeRequest.amount,
-            stakeRequest.beneficiary,
-            stakeRequest.gasPrice,
-            stakeRequest.gasLimit,
-            stakeRequest.nonce,
+            _amount,
+            _beneficiary,
+            _gasPrice,
+            _gasLimit,
+            _nonce,
             _hashLock,
-            stakeRequest.gateway
+            _gateway
         );
     }
 
@@ -308,45 +285,89 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
      * @notice It can only be called by Staker of the stake request. It deletes the
      *         previously requested stake request.
      *
-     * @param _stakeRequestHash Hash of the stake request.
+     * @param _amount Amount that is to be staked.
+     * @param _beneficiary The address in the auxiliary chain where the utility
+     *                     tokens will be minted.
+     * @param _gasPrice Gas price that staker is ready to pay to get the stake
+     *                  and mint process done.
+     * @param _gasLimit Gas limit that staker is ready to pay.
+     * @param _nonce Staker nonce specific to gateway.
+     * @param _gateway Address of the gateway to stake.
      */
     function revokeStakeRequest(
-        bytes32 _stakeRequestHash
+        uint256 _amount,
+        address _beneficiary,
+        uint256 _gasPrice,
+        uint256 _gasLimit,
+        uint256 _nonce,
+        EIP20GatewayInterface _gateway
     )
         external
     {
-        address staker = stakeRequests[_stakeRequestHash].staker;
+        address staker = msg.sender;
+        bytes32 stakeRequestHash = hashStakeRequest(
+            _amount,
+            _beneficiary,
+            _gasPrice,
+            _gasLimit,
+            _nonce,
+            staker,
+            address(_gateway)
+        );
+
         require(
-            staker == msg.sender,
+            stakeRequests[stakeRequestHash],
             "Only valid staker can revoke the stake request."
         );
 
-        removeStakeRequest(_stakeRequestHash);
+        removeStakeRequest(staker, _amount, _gateway, stakeRequestHash);
 
-        emit StakeRevoked(staker, _stakeRequestHash);
+        emit StakeRevoked(staker, stakeRequestHash);
     }
 
     /**
      * @notice It can only be called by Facilitator. It deletes the previously
      *         requested stake request.
      *
-     * @param _stakeRequestHash Hash of the stake request.
+     * @param _amount Amount that is to be staked.
+     * @param _beneficiary The address in the auxiliary chain where the utility
+     *                     tokens will be minted.
+     * @param _gasPrice Gas price that staker is ready to pay to get the stake
+     *                  and mint process done.
+     * @param _gasLimit Gas limit that staker is ready to pay.
+     * @param _nonce Staker nonce specific to gateway.
+     * @param _staker StakerProxy contract address of staker.
+     * @param _gateway Address of the gateway to stake.
      */
     function rejectStakeRequest(
-        bytes32 _stakeRequestHash
+        uint256 _amount,
+        address _beneficiary,
+        uint256 _gasPrice,
+        uint256 _gasLimit,
+        uint256 _nonce,
+        address _staker,
+        EIP20GatewayInterface _gateway
     )
         external
         onlyWorker
     {
-        address staker = stakeRequests[_stakeRequestHash].staker;
+        bytes32 stakeRequestHash = hashStakeRequest(
+            _amount,
+            _beneficiary,
+            _gasPrice,
+            _gasLimit,
+            _nonce,
+            _staker,
+            address(_gateway)
+        );
         require(
-            staker != address(0),
+            stakeRequests[stakeRequestHash],
             "Invalid stake request hash."
         );
 
-        removeStakeRequest(_stakeRequestHash);
+        removeStakeRequest(_staker, _amount, _gateway, stakeRequestHash);
 
-        emit StakeRejected(staker, _stakeRequestHash);
+        emit StakeRejected(_staker, stakeRequestHash);
     }
 
     /**
@@ -371,28 +392,28 @@ contract OSTComposer is Organized, Mutex, ComposerInterface {
     /**
      * @notice It is used by revokeStakeRequest and removeStakeRequest methods.
      *         It transfers the value tokens to staker and deletes
-     *         `stakeRequestHashes` and `stakeRequests` storage references.
+     *         `stakeRequestHashes` storage references.
      *
-     * @param _stakeRequestHash Hash of the stake request.
+     * @param _staker StakerProxy contract address of staker.
+     * @param _amount Amount that is to be staked.
+     * @param _gateway Address of the gateway to stake.
+     * @param _stakeRequestHash Stake request intent hash.
      */
     function removeStakeRequest(
+        address _staker,
+        uint256 _amount,
+        EIP20GatewayInterface _gateway,
         bytes32 _stakeRequestHash
     )
         private
     {
-        StakeRequest storage stakeRequest = stakeRequests[_stakeRequestHash];
-        address staker = stakeRequests[_stakeRequestHash].staker;
-
-        EIP20GatewayInterface gateway = stakeRequests[_stakeRequestHash].gateway;
-        uint256 amount = stakeRequests[_stakeRequestHash].amount;
-
-        delete stakeRequestHashes[staker][address(stakeRequest.gateway)];
+        delete stakeRequestHashes[_staker][address(_gateway)];
         delete stakeRequests[_stakeRequestHash];
 
-        EIP20Interface valueToken = gateway.valueToken();
+        EIP20Interface valueToken = _gateway.valueToken();
 
         require(
-            valueToken.transfer(staker, amount),
+            valueToken.transfer(_staker, _amount),
             "Staked amount must be transferred to staker."
         );
     }

--- a/contracts/test/gateway/TestOSTComposer.sol
+++ b/contracts/test/gateway/TestOSTComposer.sol
@@ -71,37 +71,16 @@ contract TestOSTComposer is OSTComposer {
      * @notice This is used for testing. It is used to set the stakeRequests
      *         storage.
      *
-     * @param _staker Address of the staker.
-     * @param _gateway Address of the gateway contract.
-     * @param _amount Amount to be staked.
-     * @param _gasPrice Gas price which staker is willing to pay.
-     * @param _gasLimit Gas limit which staker is willing to pay.
-     * @param _beneficiary Address of the account on sidechains which will
-     *                     receive OSTPrime.
-     * @param _nonce Nonce of the staker.
      * @param _stakeHash Unique hash for the request.
+     * @param _value True/false boolean value.
      */
     function setStakeRequests(
-        address _staker,
-        EIP20GatewayInterface _gateway,
-        uint256 _amount,
-        uint256 _gasPrice,
-        uint256 _gasLimit,
-        address _beneficiary,
-        uint256 _nonce,
-        bytes32 _stakeHash
+        bytes32 _stakeHash,
+        bool _value
     )
         external
     {
-        stakeRequests[_stakeHash] = StakeRequest({
-            amount: _amount,
-            beneficiary: _beneficiary,
-            gasPrice: _gasPrice,
-            gasLimit: _gasLimit,
-            nonce: _nonce,
-            staker: _staker,
-            gateway: _gateway
-        });
+        stakeRequests[_stakeHash] = _value;
     }
 
     /**

--- a/test/gateway/ost_composer/accept_stake.js
+++ b/test/gateway/ost_composer/accept_stake.js
@@ -50,7 +50,11 @@ contract('OSTComposer.acceptStakeRequest() ', (accounts) => {
     stakeRequest.gasLimit = new BN(100);
     stakeRequest.nonce = new BN(42);
     gateway = await Gateway.new();
-    stakeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address);
+    stakeHash = ComposerUtils.getStakeRequestHash(
+      stakeRequest,
+      gateway.address,
+      ostComposer.address,
+    );
     hashLock = Utils.generateHashLock().l;
     await ostComposer.setStakeRequestHash(stakeHash, stakeRequest.staker, gateway.address);
     await ostComposer.setStakeRequests(

--- a/test/gateway/ost_composer/helpers/composer_utils.js
+++ b/test/gateway/ost_composer/helpers/composer_utils.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+/**
+ * Stake Request object contains all the properties needed for generating stake request hash.
+ * @typedef {Object} StakeRequest
+ * @property {BN} amount Stake amount.
+ * @property {string} beneficiary Address of beneficiary on auxiliary chain.
+ * @property {BN} gasPrice Gas price that staker is ready to pay to get the stake
+ *                         and mint process done.
+ * @property {BN} gasLimit Gas limit that staker is ready to pay.
+ * @property {BN} nonce Stake nonce.
+ * @property {string} staker Address of staker.
+ */
+
+const web3 = require('../../../test_lib/web3.js');
+
+class ComposerUtils {
+
+  /**
+   * Generates stake request hash.
+   *
+   * @param {object} stakeRequest StakeRequest object
+   * @param {string} gateway Gateway contract address.
+   * @return {string} Stake request hash.
+   */
+  static getStakeRequestHash(stakeRequest, gateway) {
+    const stakeRequestMethod = 'StakeRequest(uint256 amount,address beneficiary,uint256 gasPrice,uint256 gasLimit,uint256 nonce,address staker,address gateway)';
+    const encodedTypeHash = web3.utils.sha3(web3.eth.abi.encodeParameter('string', stakeRequestMethod));
+
+    const stakeIntentTypeHash = web3.utils.soliditySha3(
+      { type: 'bytes32', value: encodedTypeHash },
+      { type: 'uint256', value: stakeRequest.amount },
+      { type: 'address', value: stakeRequest.beneficiary },
+      { type: 'uint256', value: stakeRequest.gasPrice },
+      { type: 'uint256', value: stakeRequest.gasLimit },
+      { type: 'uint256', value: stakeRequest.nonce },
+      { type: 'address', value: stakeRequest.staker },
+      { type: 'address', value: gateway },
+    );
+
+    return stakeIntentTypeHash;
+  }
+}
+
+module.exports = ComposerUtils;

--- a/test/gateway/ost_composer/reject_stake_request.js
+++ b/test/gateway/ost_composer/reject_stake_request.js
@@ -50,7 +50,11 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
     stakeRequest.gasLimit = new BN(100);
     stakeRequest.nonce = new BN(0);
     gateway = await Gateway.new();
-    stakeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address);
+    stakeHash = ComposerUtils.getStakeRequestHash(
+      stakeRequest,
+      gateway.address,
+      ostComposer.address,
+    );
     await ostComposer.setStakeRequestHash(stakeHash, stakeRequest.staker, gateway.address);
     await ostComposer.setStakeRequests(
       stakeHash,

--- a/test/gateway/ost_composer/reject_stake_request.js
+++ b/test/gateway/ost_composer/reject_stake_request.js
@@ -26,6 +26,7 @@ const StakerProxy = artifacts.require('StakerProxy');
 const BN = require('bn.js');
 const Utils = require('../../test_lib/utils');
 const EventDecoder = require('../../test_lib/event_decoder.js');
+const ComposerUtils = require('./helpers/composer_utils');
 
 contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
   let organization;
@@ -49,17 +50,11 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
     stakeRequest.gasLimit = new BN(100);
     stakeRequest.nonce = new BN(0);
     gateway = await Gateway.new();
-    stakeHash = await web3.utils.sha3('mockedhash');
+    stakeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address);
     await ostComposer.setStakeRequestHash(stakeHash, stakeRequest.staker, gateway.address);
     await ostComposer.setStakeRequests(
-      stakeRequest.staker,
-      gateway.address,
-      stakeRequest.amount,
-      stakeRequest.gasPrice,
-      stakeRequest.gasLimit,
-      stakeRequest.beneficiary,
-      stakeRequest.nonce,
       stakeHash,
+      true,
     );
     gatewayCount = new BN(2);
     stakerProxy = await StakerProxy.new(stakeRequest.staker);
@@ -68,10 +63,15 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
 
   it('should be able to successfully reject stake', async () => {
     const response = await ostComposer.rejectStakeRequest(
-      stakeHash,
+      stakeRequest.amount,
+      stakeRequest.beneficiary,
+      stakeRequest.gasPrice,
+      stakeRequest.gasLimit,
+      stakeRequest.nonce,
+      stakeRequest.staker,
+      gateway.address,
       { from: worker },
     );
-
     assert.strictEqual(response.receipt.status, true, 'Receipt status is unsuccessful');
 
     // Verifying the storage stakeRequestHash and stakeRequests. After the rejectStakeRequest
@@ -81,60 +81,29 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
       gateway.address,
     );
 
-    const stakeRequestsStorage = await ostComposer.stakeRequests.call(stakeHash);
-
     assert.strictEqual(
       stakeRequestHashStorage,
       Utils.ZERO_BYTES32,
       `Stake requests of ${stakeRequest.staker} for ${gateway.address} is not cleared`,
     );
 
+    const boolValue = await ostComposer.stakeRequests.call(stakeHash);
     assert.strictEqual(
-      stakeRequestsStorage.amount.eqn(0),
-      true,
-      `Expected amount is 0 but got ${stakeRequestsStorage.amount}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.beneficiary,
-      Utils.NULL_ADDRESS,
-      'Beneficiary address must be reset to null address',
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gasPrice.eqn(0),
-      true,
-      `Expected gasPrice is 0 but got ${stakeRequestsStorage.gasPrice}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gasLimit.eqn(0),
-      true,
-      `Expected gasLimit is 0 but got ${stakeRequestsStorage.gasLimit}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.nonce.eqn(0),
-      true,
-      `Expected nonce is 0 but got ${stakeRequestsStorage.nonce}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.staker,
-      Utils.NULL_ADDRESS,
-      'Staker address must be reset to null address',
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gateway,
-      Utils.NULL_ADDRESS,
-      'Gateway address must be reset to null address',
+      boolValue,
+      false,
+      `Expected value is false but got ${boolValue}`,
     );
   });
 
   it('should emit StakeRejected event', async () => {
     const tx = await ostComposer.rejectStakeRequest(
-      stakeHash,
+      stakeRequest.amount,
+      stakeRequest.beneficiary,
+      stakeRequest.gasPrice,
+      stakeRequest.gasLimit,
+      stakeRequest.nonce,
+      stakeRequest.staker,
+      gateway.address,
       { from: worker },
     );
 
@@ -157,7 +126,13 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
     const valueToken = await SpyToken.at(await gateway.valueToken.call());
 
     await ostComposer.rejectStakeRequest(
-      stakeHash,
+      stakeRequest.amount,
+      stakeRequest.beneficiary,
+      stakeRequest.gasPrice,
+      stakeRequest.gasLimit,
+      stakeRequest.nonce,
+      stakeRequest.staker,
+      gateway.address,
       { from: worker },
     );
 
@@ -178,10 +153,32 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
     const nonWorker = accounts[10];
     await Utils.expectRevert(
       ostComposer.rejectStakeRequest(
-        stakeHash,
+        stakeRequest.amount,
+        stakeRequest.beneficiary,
+        stakeRequest.gasPrice,
+        stakeRequest.gasLimit,
+        stakeRequest.nonce,
+        stakeRequest.staker,
+        gateway.address,
         { from: nonWorker },
       ),
       'Only whitelisted workers are allowed to call this method.',
+    );
+  });
+
+  it('should fail when there is mismatch while constructing stake request hash ', async () => {
+    await Utils.expectRevert(
+      ostComposer.rejectStakeRequest(
+        stakeRequest.amount,
+        stakeRequest.beneficiary,
+        stakeRequest.gasPrice,
+        stakeRequest.gasLimit,
+        stakeRequest.nonce,
+        accounts[3],
+        gateway.address,
+        { from: worker },
+      ),
+      'Invalid stake request hash.',
     );
   });
 
@@ -190,9 +187,15 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
     await spyValueToken.setTransferFakeResponse(false);
 
     await Utils.expectRevert(
-      ostComposer.revokeStakeRequest(
-        stakeHash,
-        { from: stakeRequest.staker },
+      ostComposer.rejectStakeRequest(
+        stakeRequest.amount,
+        stakeRequest.beneficiary,
+        stakeRequest.gasPrice,
+        stakeRequest.gasLimit,
+        stakeRequest.nonce,
+        stakeRequest.staker,
+        gateway.address,
+        { from: worker },
       ),
       'Staked amount must be transferred to staker.',
     );

--- a/test/gateway/ost_composer/request_stake.js
+++ b/test/gateway/ost_composer/request_stake.js
@@ -23,25 +23,8 @@ const SpyToken = artifacts.require('SpyToken');
 const Gateway = artifacts.require('SpyEIP20Gateway');
 const BN = require('bn.js');
 const Utils = require('../../test_lib/utils');
+const ComposerUtils = require('./helpers/composer_utils');
 const EventDecoder = require('../../test_lib/event_decoder.js');
-
-function getStakeRequestHash(stakeRequest, gateway) {
-  const stakeRequestMethod = 'StakeRequest(uint256 amount,address beneficiary,uint256 gasPrice,uint256 gasLimit,uint256 nonce,address staker,address gateway)';
-  const encodedTypeHash = web3.utils.sha3(web3.eth.abi.encodeParameter('string', stakeRequestMethod));
-
-  const stakeIntentTypeHash = web3.utils.soliditySha3(
-    { type: 'bytes32', value: encodedTypeHash },
-    { type: 'uint256', value: stakeRequest.amount },
-    { type: 'address', value: stakeRequest.beneficiary },
-    { type: 'uint256', value: stakeRequest.gasPrice },
-    { type: 'uint256', value: stakeRequest.gasLimit },
-    { type: 'uint256', value: stakeRequest.nonce },
-    { type: 'address', value: stakeRequest.staker },
-    { type: 'address', value: gateway.address },
-  );
-
-  return stakeIntentTypeHash;
-}
 
 contract('OSTComposer.requestStake() ', (accounts) => {
   let organization;
@@ -71,11 +54,10 @@ contract('OSTComposer.requestStake() ', (accounts) => {
       gateway.address,
       { from: stakeRequest.staker },
     );
-
     assert.strictEqual(response.receipt.status, true, 'Receipt status is unsuccessful');
 
     // Verifying the storage `stakeRequestHash` and `stakeRequests`.
-    const stakeIntentTypeHash = getStakeRequestHash(stakeRequest, gateway);
+    const stakeIntentTypeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address);
 
     const stakeRequestHashStorage = await ostComposer.stakeRequestHashes.call(
       stakeRequest.staker,
@@ -87,48 +69,12 @@ contract('OSTComposer.requestStake() ', (accounts) => {
       `Stake requests of ${stakeRequest.staker} for ${gateway.address} is not cleared`,
     );
 
-    const stakeRequestsStorage = await ostComposer.stakeRequests.call(stakeIntentTypeHash);
+    const boolValue = await ostComposer.stakeRequests.call(stakeIntentTypeHash);
 
     assert.strictEqual(
-      stakeRequestsStorage.gateway,
-      gateway.address,
-      'Gateway address for the request is incorrect',
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.amount.eq(stakeRequest.amount),
+      boolValue,
       true,
-      `Expected staked amount is ${stakeRequest.amount} but got ${stakeRequestsStorage.amount}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.beneficiary,
-      stakeRequest.beneficiary,
-      'Incorrect beneficiary address',
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gasPrice.eq(stakeRequest.gasPrice),
-      true,
-      `Expected gasPrice is ${stakeRequest.gasPrice} but got ${stakeRequestsStorage.gasPrice}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gasLimit.eq(stakeRequest.gasLimit),
-      true,
-      `Expected gasLimit is ${stakeRequest.gasLimit} but got ${stakeRequestsStorage.gasLimit}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.nonce.eq(stakeRequest.nonce),
-      true,
-      `Expected nonce is ${stakeRequest.nonce} but got ${stakeRequestsStorage.nonce}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.staker,
-      stakeRequest.staker,
-      'Incorrect staker address',
+      'Invalid stake request.',
     );
   });
 
@@ -143,7 +89,7 @@ contract('OSTComposer.requestStake() ', (accounts) => {
       { from: stakeRequest.staker },
     );
 
-    const stakeIntentTypeHash = getStakeRequestHash(stakeRequest, gateway);
+    const stakeIntentTypeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address);
     assert.strictEqual(
       response,
       stakeIntentTypeHash,

--- a/test/gateway/ost_composer/request_stake.js
+++ b/test/gateway/ost_composer/request_stake.js
@@ -18,7 +18,6 @@
 //
 // ----------------------------------------------------------------------------
 
-const EthUtils = require('ethereumjs-util');
 const OSTComposer = artifacts.require('OSTComposer');
 const SpyToken = artifacts.require('SpyToken');
 const Gateway = artifacts.require('SpyEIP20Gateway');
@@ -59,7 +58,11 @@ contract('OSTComposer.requestStake() ', (accounts) => {
     assert.strictEqual(response.receipt.status, true, 'Receipt status is unsuccessful');
 
     // Verifying the storage `stakeRequestHash` and `stakeRequests`.
-    const stakeIntentTypeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address, ostComposer.address);
+    const stakeIntentTypeHash = ComposerUtils.getStakeRequestHash(
+      stakeRequest,
+      gateway.address,
+      ostComposer.address,
+    );
 
     const stakeRequestHashStorage = await ostComposer.stakeRequestHashes.call(
       stakeRequest.staker,
@@ -91,7 +94,11 @@ contract('OSTComposer.requestStake() ', (accounts) => {
       { from: stakeRequest.staker },
     );
 
-    const stakeIntentTypeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address, ostComposer.address);
+    const stakeIntentTypeHash = ComposerUtils.getStakeRequestHash(
+      stakeRequest,
+      gateway.address,
+      ostComposer.address,
+    );
     assert.strictEqual(
       response,
       stakeIntentTypeHash,
@@ -215,7 +222,7 @@ contract('OSTComposer.requestStake() ', (accounts) => {
 
   it('should fail when staker nonce is incorrect', async () => {
     // Here, the correct nonce is 0.
-    const nonce = stakeRequest.nonce.addn(1) ;
+    const nonce = stakeRequest.nonce.addn(1);
     await Utils.expectRevert(
       ostComposer.requestStake(
         stakeRequest.amount,

--- a/test/gateway/ost_composer/revoke_stake_request.js
+++ b/test/gateway/ost_composer/revoke_stake_request.js
@@ -44,7 +44,11 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
     stakeRequest.gasLimit = new BN(100);
     stakeRequest.nonce = new BN(0);
     gateway = await Gateway.new();
-    stakeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address);
+    stakeHash = ComposerUtils.getStakeRequestHash(
+      stakeRequest,
+      gateway.address,
+      ostComposer.address,
+    );
     await ostComposer.setStakeRequestHash(stakeHash, stakeRequest.staker, gateway.address);
     await ostComposer.setStakeRequests(
       stakeHash,

--- a/test/gateway/ost_composer/revoke_stake_request.js
+++ b/test/gateway/ost_composer/revoke_stake_request.js
@@ -24,6 +24,7 @@ const Gateway = artifacts.require('SpyEIP20Gateway');
 const BN = require('bn.js');
 const Utils = require('../../test_lib/utils');
 const EventDecoder = require('../../test_lib/event_decoder.js');
+const ComposerUtils = require('./helpers/composer_utils');
 
 contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
   let organization;
@@ -43,27 +44,25 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
     stakeRequest.gasLimit = new BN(100);
     stakeRequest.nonce = new BN(0);
     gateway = await Gateway.new();
-    stakeHash = await web3.utils.sha3('mockedhash');
+    stakeHash = ComposerUtils.getStakeRequestHash(stakeRequest, gateway.address);
     await ostComposer.setStakeRequestHash(stakeHash, stakeRequest.staker, gateway.address);
     await ostComposer.setStakeRequests(
-      stakeRequest.staker,
-      gateway.address,
-      stakeRequest.amount,
-      stakeRequest.gasPrice,
-      stakeRequest.gasLimit,
-      stakeRequest.beneficiary,
-      stakeRequest.nonce,
       stakeHash,
+      true,
     );
     gatewayCount = new BN(2);
   });
 
   it('should be able to successfully revoke stake request', async () => {
     const response = await ostComposer.revokeStakeRequest(
-      stakeHash,
+      stakeRequest.amount,
+      stakeRequest.beneficiary,
+      stakeRequest.gasPrice,
+      stakeRequest.gasLimit,
+      stakeRequest.nonce,
+      gateway.address,
       { from: stakeRequest.staker },
     );
-
     assert.strictEqual(response.receipt.status, true, 'Receipt status is unsuccessful');
 
     // Verifying the storage stakeRequestHash and stakeRequests. After the revokeStakeRequest
@@ -78,53 +77,22 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
       `Stake requests of ${stakeRequest.staker} for ${gateway.address} is not cleared`,
     );
 
-    const stakeRequestsStorage = await ostComposer.stakeRequests.call(stakeHash);
+    const boolValue = await ostComposer.stakeRequests.call(stakeHash);
     assert.strictEqual(
-      stakeRequestsStorage.amount.eqn(0),
-      true,
-      `Expected amount is 0 but got ${stakeRequestsStorage.amount}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.beneficiary,
-      Utils.NULL_ADDRESS,
-      'Beneficiary address must be reset to null address',
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gasPrice.eqn(0),
-      true,
-      `Expected gasPrice is 0 but got ${stakeRequestsStorage.gasPrice}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gasLimit.eqn(0),
-      true,
-      `Expected gasLimit is 0 but got ${stakeRequestsStorage.gasLimit}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.nonce.eqn(0),
-      true,
-      `Expected nonce is 0 but got ${stakeRequestsStorage.nonce}`,
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.staker,
-      Utils.NULL_ADDRESS,
-      'Staker address must be reset to null address',
-    );
-
-    assert.strictEqual(
-      stakeRequestsStorage.gateway,
-      Utils.NULL_ADDRESS,
-      'Gateway address must be reset to null address',
+      boolValue,
+      false,
+      `Expected value is false but got ${boolValue}`,
     );
   });
 
   it('should emit StakeRevoked event', async () => {
     const tx = await ostComposer.revokeStakeRequest(
-      stakeHash,
+      stakeRequest.amount,
+      stakeRequest.beneficiary,
+      stakeRequest.gasPrice,
+      stakeRequest.gasLimit,
+      stakeRequest.nonce,
+      gateway.address,
       { from: stakeRequest.staker },
     );
 
@@ -146,7 +114,12 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
   it('should be able to transfer the value tokens to staker', async () => {
     const valueToken = await SpyToken.at(await gateway.valueToken.call());
     await ostComposer.revokeStakeRequest(
-      stakeHash,
+      stakeRequest.amount,
+      stakeRequest.beneficiary,
+      stakeRequest.gasPrice,
+      stakeRequest.gasLimit,
+      stakeRequest.nonce,
+      gateway.address,
       { from: stakeRequest.staker },
     );
 
@@ -167,7 +140,12 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
     const nonStaker = accounts[10];
     await Utils.expectRevert(
       ostComposer.revokeStakeRequest(
-        stakeHash,
+        stakeRequest.amount,
+        stakeRequest.beneficiary,
+        stakeRequest.gasPrice,
+        stakeRequest.gasLimit,
+        stakeRequest.nonce,
+        gateway.address,
         { from: nonStaker },
       ),
       'Only valid staker can revoke the stake request.',
@@ -180,7 +158,12 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
 
     await Utils.expectRevert(
       ostComposer.revokeStakeRequest(
-        stakeHash,
+        stakeRequest.amount,
+        stakeRequest.beneficiary,
+        stakeRequest.gasPrice,
+        stakeRequest.gasLimit,
+        stakeRequest.nonce,
+        gateway.address,
         { from: stakeRequest.staker },
       ),
       'Staked amount must be transferred to staker.',


### PR DESCRIPTION
- stakeRequests mapping has been updated to
  ```mapping(bytes32 => bool) public stakeRequests```

- StakeRequest objects contract's storage optimization

- Below method interfaces has been updated so that stakeRequestHash can be calculated: 
   - acceptStakeRequest()
   - revokeStakeRequest()
   - rejectStakeRequest()

Please see detailed gas analysis in the ticket.

Fixes #770 