### PR TITLE
`npm run update` does not install deps of submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,16 @@ This section is only required if you want to *set up a **new** mosaic chain.*
 #### Installation
 
 ```bash
-git clone git@github.com:OpenST/mosaic-contracts.git
+git clone https://github.com/OpenST/mosaic-contracts.git
 cd mosaic-contracts
-npm install
-npm run compile-all
+npm run update # Runs `git submodule update --init --recursive && npm ci`
+npm run compile:all
 ```
 
 #### Usage
 
 There is a deployment tool available for deployment and set-up:
+
 ```bash
 node ./tools/blue_deployment/index.js
 ```
@@ -89,15 +90,12 @@ You can use [mosaic.js] directly to deploy the contracts and interact with them.
 ### Set-up
 
 ```bash
-git clone git@github.com:OpenST/mosaic-contracts.git
+git clone https://github.com/OpenST/mosaic-contracts.git
 cd mosaic-contracts
-npm install
-npm run compile-all
+npm run update # Runs `git submodule update --init --recursive && npm ci`
+npm run compile:all
 npm run ganache
 npm run test
-
-# Requires docker, stop ganache first:
-npm run test:integration
 ```
 
 ### Guidelines

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "web3": "1.0.0-beta.36"
   },
   "scripts": {
-    "update": "git submodule update --init --recursive && npm ci && cd contracts/utilitytoken && npm ci && cd -",
+    "update": "git submodule update --init --recursive && npm ci",
     "compile": "truffle compile",
-    "compile-all": "truffle compile --all",
     "compile:ts": "tsc --target es5",
+    "compile:all": "truffle compile --all && tsc --target es5",
     "generate_test_proofs": "./proof_generation/main.sh",
     "test": "npm run test:deployment_tool && npm run test:fuzzy_proof_generator && npm run test:integration && npm run test:unit && npm run build-package",
     "test:range": "./tools/test_range.sh",
@@ -65,7 +65,7 @@
     "test:unit": "truffle test",
     "ganache": "sh tools/runGanacheCli.sh",
     "build-package": "node tools/build_package.js",
-    "prepare": "npm run compile-all && npm run build-package",
+    "prepare": "npm run compile:all && npm run build-package",
     "deploy:gateway": "npm run compile && node tools/blue_deployment/scripts/step1_origin_contracts.js",
     "lint": "eslint {test,test_integration,tools,proof_generation} -c .eslintrc.json --ext .js --ext .ts"
   },


### PR DESCRIPTION
- Changed repository clone URL to `HTTPS`
- Change `npm install` command instructions in README to `npm run update`.
- Rename `npm run compile-all` to `npm run compile:all`.
- `npm run compile:all` now compiles typescript files used during tests.