### PR TITLE
OSTComposer bug fixes

### DIFF
--- a/contracts/gateway/EIP20GatewayInterface.sol
+++ b/contracts/gateway/EIP20GatewayInterface.sol
@@ -78,7 +78,7 @@ interface EIP20GatewayInterface {
      *
      * @return The address of the value token.
      */
-    function valueToken() external view returns (EIP20Interface);
+    function token() external view returns (EIP20Interface);
 
     /**
      * @notice Get the base token of this gateway.

--- a/contracts/gateway/OSTComposer.sol
+++ b/contracts/gateway/OSTComposer.sol
@@ -198,7 +198,7 @@ contract OSTComposer is Organized, Mutex {
 
         stakeRequests[stakeRequestHash_] = true;
 
-        EIP20Interface valueToken = _gateway.valueToken();
+        EIP20Interface valueToken = _gateway.token();
 
         require(
             valueToken.transferFrom(msg.sender, address(this), _amount),
@@ -271,7 +271,7 @@ contract OSTComposer is Organized, Mutex {
         delete stakeRequestHashes[_staker][address(_gateway)];
         delete stakeRequests[stakeRequestHash];
 
-        EIP20Interface valueToken = _gateway.valueToken();
+        EIP20Interface valueToken = _gateway.token();
         require(
             valueToken.transfer(address(stakerProxy), _amount),
             "Staked amount must be transferred to the staker proxy."
@@ -427,7 +427,7 @@ contract OSTComposer is Organized, Mutex {
         delete stakeRequestHashes[_staker][address(_gateway)];
         delete stakeRequests[_stakeRequestHash];
 
-        EIP20Interface valueToken = _gateway.valueToken();
+        EIP20Interface valueToken = _gateway.token();
 
         require(
             valueToken.transfer(_staker, _amount),

--- a/contracts/gateway/OSTComposer.sol
+++ b/contracts/gateway/OSTComposer.sol
@@ -53,6 +53,7 @@ contract OSTComposer is Organized, Mutex {
         uint256 gasLimit,
         uint256 nonce,
         address indexed staker,
+        address stakerProxy,
         address gateway,
         bytes32 stakeRequestHash
     );
@@ -212,6 +213,7 @@ contract OSTComposer is Organized, Mutex {
             _gasLimit,
             _nonce,
             msg.sender,
+            address(stakerProxy),
             address(_gateway),
             stakeRequestHash_
         );

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -23,6 +23,7 @@ pragma solidity ^0.5.0;
 import "./EIP20GatewayInterface.sol";
 import "../lib/EIP20Interface.sol";
 import "../lib/Mutex.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 
 /**
@@ -33,6 +34,11 @@ import "../lib/Mutex.sol";
  *         receive all stored value.
  */
 contract StakerProxy is Mutex {
+
+    /* Usings */
+
+    using SafeMath for uint256;
+
 
     /* Storage */
 
@@ -179,10 +185,20 @@ contract StakerProxy is Mutex {
         private
     {
         EIP20Interface valueToken = _gateway.token();
-        valueToken.approve(address(_gateway), _amount);
-
-        uint256 bounty = _gateway.bounty();
         EIP20Interface baseToken = _gateway.baseToken();
-        baseToken.approve(address(_gateway), bounty);
+        uint256 bounty = _gateway.bounty();
+
+        /*
+         * When valueToken and baseToken addresses are same, then the second
+         * approval will override the first approval. So, in this case, total
+         * approval amount is sum of bounty and staked amount.
+         */
+        if (address(valueToken) == address(baseToken)) {
+            uint256 totalAmountToBeApproved = _amount.add(bounty);
+            valueToken.approve(address(_gateway), totalAmountToBeApproved);
+        } else {
+            valueToken.approve(address(_gateway), _amount);
+            baseToken.approve(address(_gateway), bounty);
+        }
     }
 }

--- a/contracts/gateway/StakerProxy.sol
+++ b/contracts/gateway/StakerProxy.sol
@@ -178,7 +178,7 @@ contract StakerProxy is Mutex {
     )
         private
     {
-        EIP20Interface valueToken = _gateway.valueToken();
+        EIP20Interface valueToken = _gateway.token();
         valueToken.approve(address(_gateway), _amount);
 
         uint256 bounty = _gateway.bounty();

--- a/contracts/test/gateway/SpyEIP20Gateway.sol
+++ b/contracts/test/gateway/SpyEIP20Gateway.sol
@@ -34,7 +34,7 @@ contract SpyEIP20Gateway {
     uint256 public expectedNonce = 42;
     bytes32 public messageHash = "b";
 
-    SpyToken public valueToken;
+    SpyToken public token;
     SpyToken public baseToken;
 
     uint256 public amount;
@@ -45,7 +45,7 @@ contract SpyEIP20Gateway {
     bytes32 public hashLock;
 
     constructor() public {
-        valueToken = new SpyToken();
+        token = new SpyToken();
         baseToken = new SpyToken();
     }
 

--- a/contracts/test/gateway/SpyEIP20Gateway.sol
+++ b/contracts/test/gateway/SpyEIP20Gateway.sol
@@ -73,4 +73,8 @@ contract SpyEIP20Gateway {
     function getNonce(address) external view returns(uint256) {
         return expectedNonce;
     }
+
+    function setBaseToken(SpyToken _baseToken) public {
+        baseToken = _baseToken;
+    }
 }

--- a/test/gateway/ost_composer/accept_stake.js
+++ b/test/gateway/ost_composer/accept_stake.js
@@ -25,7 +25,6 @@ const MockOrganization = artifacts.require('MockOrganization');
 
 const BN = require('bn.js');
 const Utils = require('../../test_lib/utils');
-const web3 = require('../../test_lib/web3');
 const ComposerUtils = require('./helpers/composer_utils');
 
 contract('OSTComposer.acceptStakeRequest() ', (accounts) => {
@@ -133,7 +132,7 @@ contract('OSTComposer.acceptStakeRequest() ', (accounts) => {
 
   it('should be able to transfer the value tokens to staker\'s staker '
     + 'proxy contract address', async () => {
-    const valueToken = await SpyToken.at(await gateway.valueToken.call());
+    const valueToken = await SpyToken.at(await gateway.token.call());
     await ostComposer.acceptStakeRequest(
       stakeRequest.amount,
       stakeRequest.beneficiary,
@@ -215,7 +214,7 @@ contract('OSTComposer.acceptStakeRequest() ', (accounts) => {
   });
 
   it('should fail when value tokens transfer to staker proxy fails', async () => {
-    const spyValueToken = await SpyToken.at(await gateway.valueToken.call());
+    const spyValueToken = await SpyToken.at(await gateway.token.call());
     await spyValueToken.setTransferFakeResponse(false);
 
     await Utils.expectRevert(

--- a/test/gateway/ost_composer/reject_stake_request.js
+++ b/test/gateway/ost_composer/reject_stake_request.js
@@ -127,7 +127,7 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
   });
 
   it('should be able to transfer the value tokens to staker', async () => {
-    const valueToken = await SpyToken.at(await gateway.valueToken.call());
+    const valueToken = await SpyToken.at(await gateway.token.call());
 
     await ostComposer.rejectStakeRequest(
       stakeRequest.amount,
@@ -187,7 +187,7 @@ contract('OSTComposer.rejectStakeRequest() ', (accounts) => {
   });
 
   it('should fail when transfer of value tokens to staker fails', async () => {
-    const spyValueToken = await SpyToken.at(await gateway.valueToken.call());
+    const spyValueToken = await SpyToken.at(await gateway.token.call());
     await spyValueToken.setTransferFakeResponse(false);
 
     await Utils.expectRevert(

--- a/test/gateway/ost_composer/request_stake.js
+++ b/test/gateway/ost_composer/request_stake.js
@@ -107,7 +107,7 @@ contract('OSTComposer.requestStake() ', (accounts) => {
   });
 
   it('should verify the transfer of staked value token', async () => {
-    const valueToken = await SpyToken.at(await gateway.valueToken.call());
+    const valueToken = await SpyToken.at(await gateway.token.call());
     await ostComposer.requestStake(
       stakeRequest.amount,
       stakeRequest.beneficiary,
@@ -264,7 +264,7 @@ contract('OSTComposer.requestStake() ', (accounts) => {
 
 
   it('should fail when transferFrom of value token fails ', async () => {
-    const valueToken = await SpyToken.at(await gateway.valueToken.call());
+    const valueToken = await SpyToken.at(await gateway.token.call());
     await valueToken.setTransferFromFakeResponse(false);
 
     await Utils.expectRevert(

--- a/test/gateway/ost_composer/request_stake.js
+++ b/test/gateway/ost_composer/request_stake.js
@@ -187,6 +187,12 @@ contract('OSTComposer.requestStake() ', (accounts) => {
       true,
       `Expected nonce amount is ${stakeRequest.nonce} but got ${eventData.nonce}`,
     );
+    const stakerProxy = await ostComposer.stakerProxies.call(stakeRequest.staker);
+    assert.strictEqual(
+      eventData.stakerProxy,
+      stakerProxy,
+      `Invalid staker proxy address`,
+    );
   });
 
   it('should fail when staked amount is 0', async () => {

--- a/test/gateway/ost_composer/revoke_stake_request.js
+++ b/test/gateway/ost_composer/revoke_stake_request.js
@@ -116,7 +116,7 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
   });
 
   it('should be able to transfer the value tokens to staker', async () => {
-    const valueToken = await SpyToken.at(await gateway.valueToken.call());
+    const valueToken = await SpyToken.at(await gateway.token.call());
     await ostComposer.revokeStakeRequest(
       stakeRequest.amount,
       stakeRequest.beneficiary,
@@ -157,7 +157,7 @@ contract('OSTComposer.revokeStakeRequest() ', (accounts) => {
   });
 
   it('should fail when transfer of value tokens to staker fails', async () => {
-    const spyValueToken = await SpyToken.at(await gateway.valueToken.call());
+    const spyValueToken = await SpyToken.at(await gateway.token.call());
     await spyValueToken.setTransferFakeResponse(false);
 
     await Utils.expectRevert(

--- a/test/gateway/staker_proxy/stake.js
+++ b/test/gateway/staker_proxy/stake.js
@@ -48,7 +48,7 @@ contract('StakerProxy.stake()', (accounts) => {
   });
 
   it('should approve and stake on the gateway', async () => {
-    const spyValueToken = await SpyToken.at(await spyGateway.valueToken.call());
+    const spyValueToken = await SpyToken.at(await spyGateway.token.call());
     const spyBaseToken = await SpyToken.at(await spyGateway.baseToken.call());
 
     await stakerProxy.stake(

--- a/test/gateway/staker_proxy/stake.js
+++ b/test/gateway/staker_proxy/stake.js
@@ -213,8 +213,6 @@ contract('StakerProxy.stake()', (accounts) => {
 
   });
 
-
-
   it('should return the message hash from the gateway', async () => {
     const messageHash = await stakerProxy.stake.call(
       amount,

--- a/test/gateway/staker_proxy/stake.js
+++ b/test/gateway/staker_proxy/stake.js
@@ -154,42 +154,6 @@ contract('StakerProxy.stake()', (accounts) => {
       { from: composer },
     );
 
-    assert.strictEqual(
-      (await spyGateway.amount.call()).toString(10),
-      amount,
-      'The spy did not record the correct amount staked.',
-    );
-
-    assert.strictEqual(
-      (await spyGateway.beneficiary.call()),
-      beneficiary,
-      'The spy did not record the correct beneficiary.',
-    );
-
-    assert.strictEqual(
-      (await spyGateway.gasPrice.call()).toString(10),
-      gasPrice,
-      'The spy did not record the correct gas price staked.',
-    );
-
-    assert.strictEqual(
-      (await spyGateway.gasLimit.call()).toString(10),
-      gasLimit,
-      'The spy did not record the correct gas limit staked.',
-    );
-
-    assert.strictEqual(
-      (await spyGateway.nonce.call()).toString(10),
-      nonce,
-      'The spy did not record the correct nonce staked.',
-    );
-
-    assert.strictEqual(
-      (await spyGateway.hashLock.call()),
-      hashLock,
-      'The spy did not record the correct hash lock staked.',
-    );
-
     const bounty = new BN(await spyGateway.bounty.call());
     const expectedApprovalAmount = bounty.addn(parseInt(amount));
     const actualApprovedAmount = await spyValueToken.approveAmount.call();


### PR DESCRIPTION
PR changes `valuetoken` variable name to `token` because deployed gateway contracts has `token` named variable which means value token address.
It also adds staker proxy address in `StakeRequested` event.

Reviewer can suggest better approach.